### PR TITLE
Integrate with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ script: sbt test
 scala: 'version defined in project/SalatBuild.scala'
 branches:
   only:
-    - pr-travis-ci  # to be removed
     - master        # built with Scala 2.8.1
     - 0.0.8_2.9.0-1 # built with Scala 2.9.1 (branch name is misleading)
 


### PR DESCRIPTION
Since Travis CI now [officially supports Scala](http://about.travis-ci.org/blog/announcing_support_for_java_scala_and_groovy_on_travis_ci/), I invite you to configure both branches 'master' and '0.0.8_2.9.0-1', to get all the benefits of this amazing Continuous Integration platform.

**Mini-HowTo plug a github project to Travis CI** (excerpt from [Travis documentation](http://about.travis-ci.org/docs/user/getting-started/)):
1. Sign in http://travis-ci.org/ through GitHub OAuth (follow the Sign In link)
2. Activate GitHub Service Hook from you [profile page](http://travis-ci.org/profile)
3. Add .travis.yml file to your repository

Since Salat branches support only one specific version of Scala, I had to override defaults in `.travis.yml`. If in the future the master branch supports a matrix of Scala versions, you can easily configure Travis to run a specific build for each version (see [Scalatra example](https://github.com/scalatra/scalatra/commit/3ddbf152b4ab33872cd8f7a0efa9b0b3b77f81c1) or [Guide: Building a Scala project with Travis](http://about.travis-ci.org/docs/user/languages/scala/)).

The current status of Salat 'master' branch is [![Build Status](https://secure.travis-ci.org/gildegoma/salat.png)](http://travis-ci.org/gildegoma/salat), **but [1 test (out of 188) currently fails on branch 0.0.8_2.9.0-1](http://travis-ci.org/#!/gildegoma/salat/builds/1028300).... +1 for Travis ;-)**

**Last but not least: Thanks to Salat Team!** 

My Salat fork has been heavily used during the creation of Travis builder for Scala, and I take the opportunity of this PR to congratulate all Salat contributors. With such nice set of Tests/Specifications, I think it really makes sense to take advantage of Travis and effortless continuous integration. 

One more special thanks to you Rose, for disabling the debug verbosity, see 0bd5c3dad92c85fa17c6bb91f87dd7525c06e291 and comments around gildegoma/salat@08b51357ca8c32dc151a0dd93d8f2cee6ece3da0)
