### PR TITLE
Fix problem with Map[String, Any], List[Any], Option[Any]

### DIFF
--- a/salat-core/src/main/scala/com/novus/salat/Grater.scala
+++ b/salat-core/src/main/scala/com/novus/salat/Grater.scala
@@ -129,6 +129,7 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
       Some((cachedFieldName(field), null))
     }
     case (null, _) => None
+    case (Some(element: AnyRef), field) => Some(cachedFieldName(field) -> toDBObject(element))
     case (element, field) => {
       field.out_!(element) match {
         case Some(None) => None
@@ -152,7 +153,7 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
             case serialized => {
               val value = serialized match {
                 case Some(unwrapped) => unwrapped
-                case _               => serialized
+                case _               => toDBObject(serialized)
               }
               Some(key -> value)
             }
@@ -299,18 +300,16 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
         case field if field.ignore => safeDefault(field)
         case field => {
           val name = cachedFieldName(field)
-          val value = dbo.get(name)
-          //          log.info(
-          //            """
-          //asObject: %s
-          //  field: %s
-          //  name: %s
-          //  dbo.get("%s"): %s
-          //  dbo.get("%s").flatMap(field.in_!(_)): %s
-          //  safeDefault: %s
-          //            """, clazz.getName, field.name, name, name, value, name, value.flatMap(field.in_!(_)), defaultArg(field).value)
-
-          value.flatMap(field.in_!(_)) orElse safeDefault(field)
+          dbo.get(name) match {
+            case Some(value) => {
+              field.in_!(value) match {
+                case Some(x: scala.collection.Map[_, _]) => Some(x.mapValues(toObject(_)))
+                case Some(x: scala.collection.Traversable[_]) => Some(x.map(toObject(_)))
+                case Some(x) => Some(toObject(x))
+              }
+            }
+            case _ => safeDefault(field)
+          }
         }
       }.map(_.get.asInstanceOf[AnyRef]) // TODO: if raw get blows up, throw a more informative error
 
@@ -447,6 +446,38 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
     // pad out with extra fields to persist
     extraFieldsToPersist.foreach(f => builder += f._2 -> DefaultArg(clazz, f._2, None))
     builder.result()
+  }
+
+  protected[salat] def toObject(value: Any): Any = value match {
+    case y: BasicDBObject if ctx.extractTypeHint(y).isDefined => ctx.lookup(y).asObject(y)
+    case y: BasicDBObject => y.mapValues(toObject(_)).toMap
+    case y: BasicDBList => y.map(toObject(_)).toList
+    case Some(x) => Some(toObject(x))
+    case _ => value
+  }
+
+  protected[salat] def toDBObject(value: AnyRef): Any = value match {
+    case y if ctx.lookup_?(y.getClass.getName).isDefined => grater[y.type].asDBObject(y)
+    case x: BasicDBObject =>  map2DBObject(x)
+    case x: BasicDBList => list2DBList(x)
+    case x: scala.collection.Map[_, AnyRef] => map2DBObject(x)
+    case x: scala.collection.Traversable[AnyRef] => list2DBList(x)
+    case Some(x: AnyRef) => toDBObject(x)
+    case _ => value
+  }
+
+  protected[salat] def map2DBObject(x: scala.collection.Map[_, AnyRef]) = {
+    val builder = MongoDBObject.newBuilder
+    x.foreach {
+      case (k, el) =>
+        builder += k.toString -> toDBObject(el)
+    }
+
+    builder.result()
+  }
+
+  protected[salat] def list2DBList(x: scala.collection.Traversable[AnyRef]) = {
+    MongoDBList(x.map(toDBObject(_)).toList: _*)
   }
 }
 

--- a/salat-core/src/main/scala/com/novus/salat/Grater.scala
+++ b/salat-core/src/main/scala/com/novus/salat/Grater.scala
@@ -129,7 +129,6 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
       Some((cachedFieldName(field), null))
     }
     case (null, _) => None
-    case (Some(element: AnyRef), field) => Some(cachedFieldName(field) -> toDBObject(element))
     case (element, field) => {
       field.out_!(element) match {
         case Some(None) => None
@@ -153,7 +152,7 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
             case serialized => {
               val value = serialized match {
                 case Some(unwrapped) => unwrapped
-                case _               => toDBObject(serialized)
+                case _               => serialized
               }
               Some(key -> value)
             }
@@ -300,16 +299,18 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
         case field if field.ignore => safeDefault(field)
         case field => {
           val name = cachedFieldName(field)
-          dbo.get(name) match {
-            case Some(value) => {
-              field.in_!(value) match {
-                case Some(x: scala.collection.Map[_, _]) => Some(x.mapValues(toObject(_)))
-                case Some(x: scala.collection.Traversable[_]) => Some(x.map(toObject(_)))
-                case Some(x) => Some(toObject(x))
-              }
-            }
-            case _ => safeDefault(field)
-          }
+          val value = dbo.get(name)
+          //          log.info(
+          //            """
+          //asObject: %s
+          //  field: %s
+          //  name: %s
+          //  dbo.get("%s"): %s
+          //  dbo.get("%s").flatMap(field.in_!(_)): %s
+          //  safeDefault: %s
+          //            """, clazz.getName, field.name, name, name, value, name, value.flatMap(field.in_!(_)), defaultArg(field).value)
+
+          value.flatMap(field.in_!(_)) orElse safeDefault(field)
         }
       }.map(_.get.asInstanceOf[AnyRef]) // TODO: if raw get blows up, throw a more informative error
 
@@ -446,38 +447,6 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
     // pad out with extra fields to persist
     extraFieldsToPersist.foreach(f => builder += f._2 -> DefaultArg(clazz, f._2, None))
     builder.result()
-  }
-
-  protected[salat] def toObject(value: Any): Any = value match {
-    case y: BasicDBObject if ctx.extractTypeHint(y).isDefined => ctx.lookup(y).asObject(y)
-    case y: BasicDBObject => y.mapValues(toObject(_)).toMap
-    case y: BasicDBList => y.map(toObject(_)).toList
-    case Some(x) => Some(toObject(x))
-    case _ => value
-  }
-
-  protected[salat] def toDBObject(value: AnyRef): Any = value match {
-    case y if ctx.lookup_?(y.getClass.getName).isDefined => grater[y.type].asDBObject(y)
-    case x: BasicDBObject =>  map2DBObject(x)
-    case x: BasicDBList => list2DBList(x)
-    case x: scala.collection.Map[_, AnyRef] => map2DBObject(x)
-    case x: scala.collection.Traversable[AnyRef] => list2DBList(x)
-    case Some(x: AnyRef) => toDBObject(x)
-    case _ => value
-  }
-
-  protected[salat] def map2DBObject(x: scala.collection.Map[_, AnyRef]) = {
-    val builder = MongoDBObject.newBuilder
-    x.foreach {
-      case (k, el) =>
-        builder += k.toString -> toDBObject(el)
-    }
-
-    builder.result()
-  }
-
-  protected[salat] def list2DBList(x: scala.collection.Traversable[AnyRef]) = {
-    MongoDBList(x.map(toDBObject(_)).toList: _*)
   }
 }
 

--- a/salat-core/src/main/scala/com/novus/salat/transformers/extract/Extractors.scala
+++ b/salat-core/src/main/scala/com/novus/salat/transformers/extract/Extractors.scala
@@ -196,6 +196,33 @@ package out {
     }
   }
 
+  object UtilsExtractor {
+    def toDBObject(value: Any)(implicit ctx: Context): Any = value match {
+      case x: BasicDBObject                         => map2DBObject(x)
+      case x: BasicDBList                           => list2DBList(x)
+      case x: scala.collection.Map[_, AnyRef]       => map2DBObject(x)
+      case x: scala.collection.Traversable[AnyRef]  => list2DBList(x)
+      case Some(x: AnyRef)                          => Some(toDBObject(x))
+      case y: AnyRef if ctx.lookup_?(Some(y.getClass.getCanonicalName).getOrElse(y.getClass.getName)).isDefined =>
+        grater[y.type].asDBObject(y)
+      case _                                        => value
+    }
+
+    private def map2DBObject(x: scala.collection.Map[_, AnyRef])(implicit ctx: Context) = {
+      val builder = MongoDBObject.newBuilder
+      x.foreach {
+        case (k, el) =>
+          builder += k.toString -> toDBObject(el)
+      }
+
+      builder.result()
+    }
+
+    private def list2DBList(x: scala.collection.Traversable[AnyRef])(implicit cxt: Context) = {
+      MongoDBList(x.map(toDBObject(_)).toList: _*)
+    }
+  }
+
   trait BigDecimalExtractor extends Transformer {
     self: Transformer =>
     override def transform(value: Any)(implicit ctx: Context): Any = ctx.bigDecimalStrategy.out(value)
@@ -250,6 +277,11 @@ package out {
       case Some(value) => Some(super.transform(value))
       case _           => None
     }
+
+    override def after(value: Any)(implicit ctx: Context): Option[Any] = value match {
+      case _ if ctx.lookup_?(path).isDefined => Some(value)
+      case _                                 => Some(UtilsExtractor.toDBObject(value))
+    }
   }
 
   trait TraversableExtractor extends Transformer {
@@ -260,7 +292,7 @@ package out {
 
     override def after(value: Any)(implicit ctx: Context): Option[Any] = value match {
       case traversable: Traversable[_] =>
-        Some(MongoDBList(traversable.map(transformElem).toList: _*))
+        Some(MongoDBList(traversable.map(transformElem).map(UtilsExtractor.toDBObject).toList: _*))
       case _ => None
     }
   }
@@ -297,7 +329,7 @@ package out {
             builder += (k match {
               case s: String => s
               case x         => x.toString
-            }) -> transformElem(el)
+            }) -> UtilsExtractor.toDBObject(transformElem(el))
         }
         Some(builder.result())
       }

--- a/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
+++ b/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
@@ -286,6 +286,18 @@ package in {
   import org.joda.time.{ DateTime, LocalDateTime, DateTimeZone }
   import org.json4s.JsonAST.JArray
 
+  object UtilsInjector {
+    def toObject(value: Any)(implicit ctx: Context): Any = value match {
+      case y: BasicDBObject if ctx.extractTypeHint(y).isDefined => ctx.lookup(y).asObject(y)
+      case y: BasicDBObject => y.mapValues(toObject(_)).toMap
+      case y: BasicDBList => y.map(toObject(_)).toList
+      case x: scala.collection.Map[_, _] => x.mapValues(toObject(_))
+      case x: scala.collection.Traversable[_] => x.map(toObject(_))
+      case Some(x) => Some(toObject(x))
+      case _ => value
+    }
+  }
+
   trait LongToInt extends Transformer {
     self: Transformer =>
     override def transform(value: Any)(implicit ctx: Context) = value match {
@@ -422,8 +434,8 @@ package in {
   trait OptionInjector extends Transformer {
     self: Transformer =>
     override def after(value: Any)(implicit ctx: Context): Option[Any] = value match {
-      case value @ Some(x) if x != null => Some(value)
-      case value if value != null       => Some(Some(value))
+      case value @ Some(x) if x != null => Some(UtilsInjector.toObject(value))
+      case value if value != null       => Some(Some(UtilsInjector.toObject(value)))
       case _                            => Some(None)
     }
   }
@@ -447,8 +459,10 @@ package in {
     }
 
     override def after(value: Any)(implicit ctx: Context): Option[Any] = value match {
-      case traversable: Traversable[_] => Some(traversableImpl(parentType, traversable.map(transformElement(_))))
-      case _                           => None
+      case traversable: Traversable[_] => Some(traversableImpl(parentType, traversable.map {
+        el => UtilsInjector.toObject(transformElement(el))
+      }))
+      case _ => None
     }
 
     val parentType: TypeRefType
@@ -490,7 +504,7 @@ package in {
       case mdbo: MongoDBObject => {
         val builder = MongoDBObject.newBuilder
         mdbo.foreach {
-          case (k, v) => builder += k -> transformElement(v)
+          case (k, v) => builder += k -> UtilsInjector.toObject(transformElement(v))
         }
         Some(mapImpl(parentType, builder.result()))
       }

--- a/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
@@ -78,15 +78,15 @@ class MapSupportSpec extends SalatSpec {
     }
 
     "support complex map" in {
-      val parameter1 = Parameter("parameter1", Some(Map("key1" -> SimpleClass())), Map("key1" -> "value1", "key2" -> 2))
+      val parameter1 = Parameter("parameter1", Some(Map("map1" -> SimpleClass())), Map("key1" -> "value1", "key2" -> 2))
       val parameter2 = Parameter("parameter2", Some(List(parameter1)), Map("key1" -> "value1", "key2" -> 2))
       val parameter3 = Parameter("parameter3", Some(SimpleClass()), Map("key1" -> "value1", "key2" -> 2, "key3" -> parameter1))
       val parameters = List(parameter1, parameter2, parameter3)
-      
+
       val data = Data("data", parameters)
-      
+
       val metadata = MetaData("metadata", parameters, List(data))
-      
+
       val id = new ObjectId().toString
 
       val view = ViewMetaData(id, metadata)
@@ -96,7 +96,7 @@ class MapSupportSpec extends SalatSpec {
 
       val coll = MongoConnection()(SalatSpecDb)("map_support_test_2")
       val wr = coll.insert(dbo)
-//      log.info("WR: %s", wr)
+      //      log.info("WR: %s", wr)
       wr.getCachedLastError must beNull
 
       val view_* = grater[ViewMetaData].asObject(coll.findOne().get)

--- a/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
@@ -31,6 +31,7 @@ import com.novus.salat.test.global._
 import com.novus.salat.test.model._
 import com.mongodb.casbah.Imports._
 import com.novus.salat.util.MapPrettyPrinter
+import org.bson.types.ObjectId
 
 class MapSupportSpec extends SalatSpec {
 
@@ -74,6 +75,32 @@ class MapSupportSpec extends SalatSpec {
 
       val ao_* = grater[AttributeObject].asObject(coll.findOne().get)
       ao_* must_== ao
+    }
+
+    "support complex map" in {
+      val parameter1 = Parameter("parameter1", Some(Map("key1" -> SimpleClass())), Map("key1" -> "value1", "key2" -> 2))
+      val parameter2 = Parameter("parameter2", Some(List(parameter1)), Map("key1" -> "value1", "key2" -> 2))
+      val parameter3 = Parameter("parameter3", Some(SimpleClass()), Map("key1" -> "value1", "key2" -> 2, "key3" -> parameter1))
+      val parameters = List(parameter1, parameter2, parameter3)
+      
+      val data = Data("data", parameters)
+      
+      val metadata = MetaData("metadata", parameters, List(data))
+      
+      val id = new ObjectId().toString
+
+      val view = ViewMetaData(id, metadata)
+
+      val dbo: MongoDBObject = grater[ViewMetaData].asDBObject(view)
+      log.info(MapPrettyPrinter(dbo))
+
+      val coll = MongoConnection()(SalatSpecDb)("map_support_test_2")
+      val wr = coll.insert(dbo)
+//      log.info("WR: %s", wr)
+      wr.getCachedLastError must beNull
+
+      val view_* = grater[ViewMetaData].asObject(coll.findOne().get)
+      view_* must_== view
     }
 
   }

--- a/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
@@ -324,6 +324,16 @@ case class MetadataRecord(
   deleted: Boolean = false // if the record has been deleted
   )
 
+case class SimpleClass(value: String = "")
+
+case class Parameter(name: String, value: Option[Any], map: Map[String, Any], list: List[Any] = Nil)
+
+case class Data(name: String, parameters: List[Any])
+
+case class MetaData(name: String, parameters: List[Parameter], data: List[Data])
+
+case class ViewMetaData(@Key("_id") id: String, metadata: MetaData)
+
 case class Order(
   id: Long,
   ordStatus: OrderStatus)


### PR DESCRIPTION
Fix problem with Map[String, Any], List[Any], Option[Any]

don't support:
    - Map[String, Any] = Map("key" -> Some("value"))
    - List[Any] = List(Some("value"))
    - Option[Any] = Some(Some("value"))
    - does not restore mutable collections in the Map[_, Any], List[Any], Option[Any]
