### PR TITLE
Expose WriteResult to callers of DAO.update

### DIFF
--- a/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
@@ -130,8 +130,9 @@ trait BaseDAOMethods[ObjectType <: AnyRef, ID <: Any] {
    *  @param upsert if the database should create the element if it does not exist
    *  @param multi if the update should be applied to all objects matching
    *  @param wc write concern
+   *  @return (WriteResult) result of write operation
    */
-  def update(q: DBObject, o: DBObject, upsert: Boolean, multi: Boolean, wc: WriteConcern)
+  def update(q: DBObject, o: DBObject, upsert: Boolean, multi: Boolean, wc: WriteConcern): WriteResult
 
   /** Performs an update operation.
    *  @param q search query for old object to update
@@ -139,8 +140,9 @@ trait BaseDAOMethods[ObjectType <: AnyRef, ID <: Any] {
    *  @param upsert if the database should create the element if it does not exist
    *  @param multi if the update should be applied to all objects matching
    *  @param wc write concern
+   *  @return (WriteResult) result of write operation
    */
-  def update(q: DBObject, t: ObjectType, upsert: Boolean, multi: Boolean, wc: WriteConcern) {
+  def update(q: DBObject, t: ObjectType, upsert: Boolean, multi: Boolean, wc: WriteConcern): WriteResult = {
     update(q = q, o = toDBObject(t), upsert = upsert, multi = multi, wc = wc)
   }
 

--- a/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
@@ -267,7 +267,7 @@ trait ModelCompanion[ObjectType <: AnyRef, ID <: Any] extends BaseDAOMethods[Obj
     dao.save(t, wc)
   }
 
-  def update(q: DBObject, o: DBObject, upsert: Boolean, multi: Boolean, wc: WriteConcern = defaultWriteConcern) {
+  def update(q: DBObject, o: DBObject, upsert: Boolean, multi: Boolean, wc: WriteConcern = defaultWriteConcern): WriteResult = {
     dao.update(q, o, upsert, multi, wc)
   }
 

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -375,14 +375,16 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    *  @param upsert if the database should create the element if it does not exist
    *  @param multi if the update should be applied to all objects matching
    *  @param wc write concern
+   *  @return (WriteResult) result of write operation
    */
-  def update(q: DBObject, o: DBObject, upsert: Boolean = false, multi: Boolean = false, wc: WriteConcern = defaultWriteConcern) {
+  def update(q: DBObject, o: DBObject, upsert: Boolean = false, multi: Boolean = false, wc: WriteConcern = defaultWriteConcern): WriteResult = {
     try {
       val wr = collection.update(q, o, upsert, multi, wc)
       val lastError = wr.getCachedLastError
       if (lastError != null && !lastError.ok()) {
         throw SalatDAOUpdateError(description, collection, q, o, wc, wr, upsert, multi)
       }
+      wr
     }
   }
 

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
@@ -116,11 +116,12 @@ class SalatDAOSpec extends SalatSpec {
       AlphaDAO.collection.count must_== 1L
 
       // need to explicitly specify upsert and multi when updating using an object instead of dbo
-      val cr = AlphaDAO.update(q = MongoDBObject("_id" -> 3),
+      val wr = AlphaDAO.update(q = MongoDBObject("_id" -> 3),
         t = alpha3.copy(beta = List[Beta](Gamma("gamma3"))),
         upsert = false,
         multi = false,
         wc = new WriteConcern())
+      wr.getN must_== 1L
 
       AlphaDAO.collection.count must_== 1L
 


### PR DESCRIPTION
Make Mongo's WriteResult available to callers when doing query-based updates. 
This allows them to determine things such as the number of rows modified by 
an update.
