### PR TITLE
Added JSON support for BSONTimestamp type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 .ensime
 *.iml
 .history
+*~

--- a/salat-core/src/main/scala/com/novus/salat/json/ToJValue.scala
+++ b/salat-core/src/main/scala/com/novus/salat/json/ToJValue.scala
@@ -33,6 +33,7 @@ import java.net.URL
 import com.novus.salat.TypeFinder
 import com.novus.salat.StringTypeHintStrategy
 import scala.tools.scalap.scalax.rules.scalasig.TypeRefType
+import org.bson.types.BSONTimestamp
 
 object ToJField extends Logging {
   def typeHint[X](clazz: Class[X], useTypeHint: Boolean)(implicit ctx: Context) = {
@@ -79,6 +80,7 @@ object ToJValue extends Logging {
       case o: ObjectId => ctx.jsonConfig.objectIdStrategy.out(o)
       case u: java.net.URL => JString(u.toString) // might as well
       case n if n == null && ctx.jsonConfig.outputNullValues => JNull
+      case ts: BSONTimestamp => ctx.jsonConfig.bsonTimestampStrategy.out(ts)
       case x: AnyRef => sys.error("serialize: Unsupported JSON transformation for class='%s', value='%s'".format(x.getClass.getName, x))
     }
 
@@ -124,6 +126,7 @@ object FromJValue extends Logging {
     }
     case o: JObject if field.tf.isOid => deserialize(o, field.tf)
     case o: JObject if field.tf.isDate || field.tf.isDateTime => deserialize(o, field.tf)
+    case o: JObject if field.tf.isBSONTimestamp => deserialize(o, field.tf)
     case o: JObject => ctx.lookup(if (childType.isDefined) childType.get.symbol.path else field.typeRefType.symbol.path).fromJSON(o)
     case x => deserialize(x, if (childType.isDefined) TypeFinder(childType.get) else field.tf)
   }
@@ -133,6 +136,7 @@ object FromJValue extends Logging {
       case v if tf.isDateTime            => ctx.jsonConfig.dateStrategy.toDateTime(v)
       case v if tf.isDate                => ctx.jsonConfig.dateStrategy.toDate(v)
       case v if tf.isOid                 => ctx.jsonConfig.objectIdStrategy.in(v)
+      case v if tf.isBSONTimestamp       => ctx.jsonConfig.bsonTimestampStrategy.in(v)
       case s: JString if tf.isChar       => s.values.charAt(0)
       case s: JString if tf.isURL        => new URL(s.values)
       case s: JString                    => s.values

--- a/salat-core/src/test/scala/com/novus/salat/test/json/BSTimestampStrategySpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/json/BSTimestampStrategySpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010 - 2012 Novus Partners, Inc. (http://www.novus.com)
+ *
+ * Module:        salat-core
+ * Class:         DateStrategySpec.scala
+ * Last modified: 2012-06-28 15:37:34 EDT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project:      http://github.com/novus/salat
+ * Wiki:         http://github.com/novus/salat/wiki
+ * Mailing list: http://groups.google.com/group/scala-salat
+ */
+
+package com.novus.salat.test.json
+
+import org.specs2.mutable.Specification
+import com.novus.salat.util.Logging
+import org.joda.time.{ DateTimeZone, DateTime }
+import com.novus.salat.json.StrictBSONTimestampStrategy
+import net.liftweb.json.JsonAST.{ JField, JObject, JInt, JString }
+import org.bson.types.BSONTimestamp
+
+class BSONTimestampStrategySpec extends Specification with Logging {
+
+  val ts = new BSONTimestamp(1345193830, 10)
+  val formatted = "{\"$ts\" : 1345193830 , \"$inc\" : 10}"
+
+  "JSON BSONTimestamp strategy " should {
+    "Strict JSON" in {
+      val s = StrictBSONTimestampStrategy
+      val j = JObject(JField("$ts", JInt(1345193830)) :: (JField("$inc", JInt(10))) :: Nil)
+
+      "from BSONTimestamp to JSON" in {
+        s.out(ts) must_== j
+      }
+      "from JSON to BSONTimestamp" in {
+        s.in(j) must_== ts
+      }
+      "throw an error when an unexpected JSON field type is submitted" in {
+        s.in(j \ "$ts") must throwA[RuntimeException]
+      }
+    }
+  }
+}

--- a/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
+++ b/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
@@ -30,6 +30,7 @@ protected[salat] object Types {
   val Date = "java.util.Date"
   val DateTime = Set("org.joda.time.DateTime", "org.scala_tools.time.TypeImports.DateTime")
   val Oid = Set("org.bson.types.ObjectId", "com.mongodb.casbah.commons.TypeImports.ObjectId")
+  val BsonTimestamp = "org.bson.types.BSONTimestamp"
   val SBigDecimal = classOf[SBigDecimal].getName
   val BigInt = classOf[BigInt].getName
   val Option = "scala.Option"
@@ -64,6 +65,7 @@ protected[salat] case class TypeFinder(t: TypeRefType) {
   lazy val isOption = TypeMatchers.matches(t, Types.Option)
   lazy val isOid = TypeMatchers.matches(t, Types.Oid)
   lazy val isURL = TypeMatchers.matches(t, classOf[java.net.URL].getName)
+  lazy val isBSONTimestamp = TypeMatchers.matches(t, Types.BsonTimestamp)
 }
 
 protected[salat] object TypeMatchers {


### PR DESCRIPTION
BSONTimestamp is used mostly in MongoDB oplog, but can be also used in any document and automatically handled by the database provided that the field is placed right after `_id`. See [this document](http://www.mongodb.org/display/DOCS/Timestamp+data+type).

The commit is tested and used in a real project.
This time the clean pull request.
