### PR TITLE
Bug fix on Long extraction from JInt objects

### DIFF
--- a/salat-core/src/test/scala/com/novus/salat/test/LongSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/LongSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010 - 2012 Novus Partners, Inc. (http://www.novus.com)
+ *
+ * Module:        salat-core
+ * Class:         FloatSpec.scala
+ * Last modified: 2012-10-15 20:40:58 EDT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *           Project:  http://github.com/novus/salat
+ *              Wiki:  http://github.com/novus/salat/wiki
+ *      Mailing list:  http://groups.google.com/group/scala-salat
+ *     StackOverflow:  http://stackoverflow.com/questions/tagged/salat
+ */
+package com.novus.salat.test
+
+import com.novus.salat._
+import com.novus.salat.test.global._
+import com.novus.salat.test.model._
+import com.mongodb.casbah.Imports._
+
+class LongSpec extends SalatSpec {
+  "A grater" should {
+    "support longs" in {
+      val a = LongSpecExample(timestamp = 1356048000000L, value = 26)
+      val dbo: MongoDBObject = grater[LongSpecExample].asDBObject(a)
+      dbo must havePair("_typeHint" -> "com.novus.salat.test.model.LongSpecExample")
+      dbo must havePair("timestamp" -> 1356048000000L)
+      dbo must havePair("value" -> 26)
+
+      val json = dbo.toString()
+      grater[LongSpecExample].fromJSON(json) must_== a
+    }
+  }
+}

--- a/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
@@ -173,6 +173,8 @@ case class Olive(awl: java.util.UUID)
 
 case class Quentin(mire: Float)
 
+case class LongSpecExample(timestamp: Long, value: Int)
+
 case class Rhoda(consumed: Option[String] = None)
 case class Rhoda2(howHot: Option[BigDecimal] = None)
 case class Rhoda3(consumed: Option[String] = None)

--- a/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
+++ b/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
@@ -67,7 +67,7 @@ protected[salat] case class TypeFinder(t: TypeRefType) {
   lazy val isShort = TypeMatchers.matches(t, classOf[Short].getName)
   lazy val isBigDecimal = Types.isBigDecimal(t.symbol)
   lazy val isBigInt = Types.isBigInt(t.symbol)
-  lazy val isLong = TypeMatchers.matches(t, classOf[Long].getName)
+  lazy val isLong = TypeMatchers.matches(t, "scala.Long")
 
   lazy val isOption = TypeMatchers.matches(t, Types.Option)
   lazy val isOid = TypeMatchers.matches(t, Types.Oid)


### PR DESCRIPTION
Long were not extracted properly when using grater[SomeCaseClass].fromJSON(obj).

The reason for that was that grater was failing to recognise the long attributes as long, because classOf[Long].getName in scala returns "long" instead of "scala.Long" (scala optimization).

The fix proposed here is on the isLong function, in TypeMatchers.
