### PR TITLE
Fix travis.sh to build the scala version matrix

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -2,4 +2,4 @@
 # thank @xuwei-k
 curl -O https://raw.github.com/paulp/sbt-extras/1dbab99024e2bec49b9171b61eac4d48654eaf26/sbt &&
 chmod u+x ./sbt &&
-./sbt -mem 512 +test
+./sbt -mem 512 -scala-version $TRAVIS_SCALA_VERSION +test


### PR DESCRIPTION
In order to build against scala versions 2.9.1 and 2.9.2, as described in `.travis.yml`, use the environment variable exported by travis builder.

Note: Travis CI will soon [use `sbt-extras` as standard sbt tool](https://github.com/travis-ci/travis-cookbooks/pull/107), and thus it will be in the future possible to get rid of extra script `scripts/travis.sh`. Since I'm tracking when travis-ci.org will be ready, I may send you a second pull request in this way (see https://github.com/gildegoma/salat/tree/sbtextras-on-travisci as preview...). 
