### PR TITLE
Bug fix for Option[Int] and Option[Long]

### DIFF
--- a/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
+++ b/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
@@ -277,10 +277,12 @@ package in {
     self: Transformer =>
 
     override def transform(value: Any)(implicit ctx: Context): Any = value match {
-      case d: Double => d.toFloat
-      case i: Int    => i.toFloat
-      case l: Long   => l.toFloat
-      case s: Short  => s.toFloat
+      case d: Double                           => d.toFloat
+      case i: Int                              => i.toFloat
+      case l: Long                             => l.toFloat
+      case s: Short                            => s.toFloat
+      case Some(d) if (d.isInstanceOf[Double]) => d.asInstanceOf[Double].toFloat
+      case Some(f) if (f.isInstanceOf[Float])  => f.asInstanceOf[Float]
     }
   }
 

--- a/salat-core/src/test/scala/com/novus/salat/test/OptionNumSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/OptionNumSpec.scala
@@ -32,11 +32,13 @@ import com.mongodb.casbah.Imports._
 class OptionNumSpec extends SalatSpec {
   "A grater" should {
     "support option there" in {
-      val a = OptionSpecExample(timestamp = Some(1356048000000L), value = Some(26))
+      val a = OptionSpecExample(timestamp = Some(1356048000000L), valueInt = Some(26), valueDouble = Some(1337.0), valueFloat = Some(31047.0f))
       val dbo: MongoDBObject = grater[OptionSpecExample].asDBObject(a)
       dbo must havePair("_typeHint" -> "com.novus.salat.test.model.OptionSpecExample")
       dbo must havePair("timestamp" -> 1356048000000L)
-      dbo must havePair("value" -> 26)
+      dbo must havePair("valueInt" -> 26)
+      dbo must havePair("valueDouble" -> 1337.0)
+      dbo must havePair("valueFloat" -> 31047.0f)
 
       val json = dbo.toString()
       grater[OptionSpecExample].fromJSON(json) must_== a

--- a/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
@@ -176,7 +176,7 @@ case class Olive(awl: java.util.UUID)
 case class Quentin(mire: Float)
 
 case class LongSpecExample(timestamp: Long, value: Int)
-case class OptionSpecExample(timestamp: Option[Long] = None, value: Option[Int] = None)
+case class OptionSpecExample(timestamp: Option[Long] = None, valueInt: Option[Int] = None, valueDouble: Option[Double] = None, valueFloat: Option[Float] = None)
 
 case class Rhoda(consumed: Option[String] = None)
 case class Rhoda2(howHot: Option[BigDecimal] = None)


### PR DESCRIPTION
I propose a bug fix for the case of case classes containing Option[Int] as attributes.

I don't know if this is the proper way to solve the problem, but it does solve it and doesn't break any other unit tests.

I have added a unit test also to reproduce the problem.
