### PR TITLE
Use again Travis CI default builder (now based on sbt-extras)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ scala:
 branches:
   only:
     - master
-# use sbt-extras runner instead of stock Travis CI sbt version
-script: sh ./scripts/travis.sh
 notifications:
   email:
     recipients:

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# thank @xuwei-k
-curl -O https://raw.github.com/paulp/sbt-extras/1dbab99024e2bec49b9171b61eac4d48654eaf26/sbt &&
-chmod u+x ./sbt &&
-./sbt -mem 512 -scala-version $TRAVIS_SCALA_VERSION +test


### PR DESCRIPTION
as promised a "long" (#63) time ago, Travis CI now relies on sbt-extras by default. No more need to install your own sbt-extras on every build to enjoy sbt autodetection and use any scala version you wish!
