### PR TITLE
Travis CI: build against Oracle and Open JDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ notifications:
     recipients:
       - prasinous@gmail.com
 jdk:
-  - openjdk6
-# these seem to segfault 2/3 of the time, need to understand why
-#  - openjdk7
-#  - oraclejdk7
+  - openjdk7
+  - oraclejdk7
 services:
   - mongodb


### PR DESCRIPTION
Travis CI has rollout the JVM builds to a new cloud infrastructure based on 64-bit Ubuntu 12.04.1. Salat seems to build fine on this new platform with OpenJDK7 and OracleJDK7, but no more with OpenJDK6.

See my tests here: https://travis-ci.org/gildegoma/salat/builds/4132394

Do you still need OpenJDK6 to be supported ?
