### PR TITLE
Test demonstrating an issue with package objects

### DIFF
--- a/salat-core/src/test/scala/com/novus/salat/test/GraterSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/GraterSpec.scala
@@ -149,6 +149,13 @@ class GraterSpec extends SalatSpec {
         val gneiss_* = grater[Gneiss].fromMap(map)
         gneiss_* must_== Gneiss(true)
       }
+
+      "support case classes in package objects" in {
+        val order = Order(42, OrderStatus.PartiallyFilled)
+        val orderMap = Map("id" -> 42, "ordStatus" -> "1")
+        val theOrder = grater[Order].fromMap(orderMap)
+        theOrder must_== order
+      }
     }
   }
 

--- a/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/model/TestModel.scala
@@ -320,3 +320,6 @@ case class MetadataRecord(
   deleted: Boolean = false // if the record has been deleted
   )
 
+case class Order(
+  id: Long,
+  ordStatus: OrderStatus)

--- a/salat-core/src/test/scala/com/novus/salat/test/model/package.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/model/package.scala
@@ -1,0 +1,12 @@
+package com.novus.salat.test
+
+package object model {
+
+  case class OrderStatus(s: String)
+  object OrderStatus {
+    val New = OrderStatus("0")
+    val PartiallyFilled = OrderStatus("1")
+    val Filled = OrderStatus("2")
+  }
+
+}


### PR DESCRIPTION
When making use of nested case classes that are declared inside of a package object, the grater seems to have trouble.

Attached is a test which demonstrates this behavior.
