### PR TITLE
Update gh pages for novus to salat transfer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>Salat by novus</title>
+    <title>Salat, the simple serialization library for case classes</title>
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/pygment_trac.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
@@ -20,9 +20,9 @@
   <body>
       <div id="header">
         <nav>
-          <li class="fork"><a href="https://github.com/novus/salat">View On GitHub</a></li>
-          <li class="downloads"><a href="https://github.com/novus/salat/zipball/master">ZIP</a></li>
-          <li class="downloads"><a href="https://github.com/novus/salat/tarball/master">TAR</a></li>
+          <li class="fork"><a href="https://github.com/salat/salat">View On GitHub</a></li>
+          <li class="downloads"><a href="https://github.com/salat/salat/zipball/master">ZIP</a></li>
+          <li class="downloads"><a href="https://github.com/salat/salat/tarball/master">TAR</a></li>
           <li class="title">DOWNLOADS</li>
         </nav>
       </div><!-- end header -->
@@ -34,7 +34,6 @@
           <h1>Salat</h1>
           <p>A simple serialization library for case classes.</p>
           <hr>
-          <span class="credits left">Project maintained by <a href="https://github.com/novus">novus</a></span>
           <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></span>
         </div>
 
@@ -69,19 +68,19 @@
 <pre><code>"com.novus" %% "salat" % "1.9.8"
 </code></pre>
 
-<p><a href="https://github.com/novus/salat/blob/master/notes/1.9.8.markdown">Release Notes</a></p>
+<p><a href="https://github.com/salat/salat/blob/master/notes/1.9.8.markdown">Release Notes</a></p>
 
 <h2>
 <a name="snapshot" class="anchor" href="#snapshot"><span class="octicon octicon-link"></span></a>Snapshot</h2>
 
-<p><a href="http://travis-ci.org/novus/salat"><img src="https://secure.travis-ci.org/novus/salat.png" alt="Build Status"></a></p>
+<p><a href="http://travis-ci.org/salat/salat"><img src="https://secure.travis-ci.org/novus/salat.png" alt="Build Status"></a></p>
 
 <p>Available for Scala 2.10 and 2.11. Based on Casbah 2.7.1.</p>
 
 <pre><code>"com.novus" %% "salat" % "1.9.9-SNAPSHOT"
 </code></pre>
 
-<p><a href="https://github.com/novus/salat/blob/master/notes/1.9.9.markdown">Release Notes (In Progress)</a></p>
+<p><a href="https://github.com/salat/salat/blob/master/notes/1.9.9.markdown">Release Notes (In Progress)</a></p>
 
 <h2>
 <a name="legacy-support" class="anchor" href="#legacy-support"><span class="octicon octicon-link"></span></a>Legacy support</h2>
@@ -122,17 +121,17 @@
 <h2>
 <a name="play-2-plugin" class="anchor" href="#play-2-plugin"><span class="octicon octicon-link"></span></a>Play 2 plugin</h2>
 
-<p>Are you using Play framework?  Make sure to see our <a href="https://github.com/novus/salat/wiki/SalatWithPlay2">Play support</a> wiki page, and check out Leon Radley's plugin at <a href="https://github.com/leon/play-salat">leon/play-salat</a>.</p>
+<p>Are you using Play framework?  Make sure to see our <a href="https://github.com/salat/salat/wiki/SalatWithPlay2">Play support</a> wiki page, and check out Leon Radley's plugin at <a href="https://github.com/leon/play-salat">leon/play-salat</a>.</p>
 
 <h1>
 <a name="documentation" class="anchor" href="#documentation"><span class="octicon octicon-link"></span></a>Documentation</h1>
 
-<p>See the <a href="https://github.com/novus/salat/wiki">wiki</a> and the <a href="http://groups.google.com/group/scala-salat">mailing list</a>.</p>
+<p>See the <a href="https://github.com/salat/salat/wiki">wiki</a> and the <a href="http://groups.google.com/group/scala-salat">mailing list</a>.</p>
 
 <h1>
 <a name="what-does-salat-support" class="anchor" href="#what-does-salat-support"><span class="octicon octicon-link"></span></a>What does Salat support?</h1>
 
-<p>See <a href="https://github.com/novus/salat/wiki/SupportedTypes">Supported Types</a>.</p>
+<p>See <a href="https://github.com/salat/salat/wiki/SupportedTypes">Supported Types</a>.</p>
 
 <h1>
 <a name="what-doesnt-salat-support" class="anchor" href="#what-doesnt-salat-support"><span class="octicon octicon-link"></span></a>What doesn't Salat support?</h1>
@@ -149,7 +148,7 @@
 <li>multiple constructors</li>
 <li>tuples</li>
 <li>
-<code>Option</code> containing a collection (see <a href="https://github.com/novus/salat/wiki/Collections">collection support</a> for workarounds)</li>
+<code>Option</code> containing a collection (see <a href="https://github.com/salat/salat/wiki/Collections">collection support</a> for workarounds)</li>
 <li>relationship management like a traditional ORM</li>
 </ul><h1>
 <a name="how-does-salat-work" class="anchor" href="#how-does-salat-work"><span class="octicon octicon-link"></span></a>How does Salat work?</h1>


### PR DESCRIPTION
Update links / remove "by Novus" verbiage.

Did not update travis.ci link.