### PR TITLE
add test for '_id: Option[ObjectId] = None'

### DIFF
--- a/project/SalatBuild.scala
+++ b/project/SalatBuild.scala
@@ -69,8 +69,8 @@ object BuildSettings {
   import Repos._
 
   val buildOrganization = "com.novus"
-  val buildVersion = "2.0.0-SNAPSHOT"
-  val buildScalaVersion = "2.11.2"
+  val buildVersion = "2.1.0-SNAPSHOT"
+  val buildScalaVersion = "2.11.7"
 
   val buildSettings = Defaults.defaultSettings ++ Format.settings ++ Publish.settings ++ Seq(
     organization := buildOrganization,
@@ -149,11 +149,11 @@ object Publish {
 object Dependencies {
 
   private val LogbackVersion = "1.0.9"
-  private val CasbahVersion = "2.7.1"
+  private val CasbahVersion = "3.1.0"
 
-  val specs2 = "org.specs2" %% "specs2" % "2.3.11" % "test"
+  val specs2 = "org.specs2" %% "specs2" % "2.3.13" % "test"
   val commonsLang = "commons-lang" % "commons-lang" % "2.6" % "test"
-  val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.2"
+  val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.14"
   val logbackCore = "ch.qos.logback" % "logback-core" % LogbackVersion % "test"
   val logbackClassic = "ch.qos.logback" % "logback-classic" % LogbackVersion % "test"
   val casbah = "org.mongodb" %% "casbah-core" % CasbahVersion

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -303,8 +303,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def insert(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
     val wr = collection.insert(dbo, wc)
-    val error = wr.getCachedLastError
-    if (error == null || (error != null && error.ok())) {
+    if (wr.wasAcknowledged()) {
       dbo.getAs[ID]("_id")
     }
     else {
@@ -320,8 +319,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def insert(docs: Traversable[ObjectType], wc: WriteConcern = defaultWriteConcern) = if (docs.nonEmpty) {
     val dbos = docs.map(decorateDBO(_)).toList
     val wr = collection.insert(dbos: _*)
-    val lastError = wr.getCachedLastError
-    if (lastError == null || (lastError != null && lastError.ok())) {
+    if (wr.wasAcknowledged()) {
       dbos.map {
         dbo =>
           dbo.getAs[ID]("_id") orElse collection.findOne(dbo).flatMap(_.getAs[ID]("_id"))
@@ -360,8 +358,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def remove(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
     val wr = collection.remove(dbo, wc)
-    val lastError = wr.getCachedLastError
-    if (lastError != null && !lastError.ok()) {
+    if (wr.wasAcknowledged()) {
       throw SalatRemoveError(description, collection, wc, wr, List(dbo))
     }
     wr
@@ -373,8 +370,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def remove[A <% DBObject](q: A, wc: WriteConcern) = {
     val wr = collection.remove(q, wc)
-    val lastError = wr.getCachedLastError
-    if (lastError != null && !lastError.ok()) {
+    if (wr.wasAcknowledged()) {
       throw SalatRemoveQueryError(description, collection, q, wc, wr)
     }
     wr
@@ -403,8 +399,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def save(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
     val wr = collection.save(dbo, wc)
-    val lastError = wr.getCachedLastError
-    if (lastError != null && !lastError.ok()) {
+    if (wr.wasAcknowledged()) {
       throw SalatSaveError(description, collection, wc, wr, List(dbo))
     }
     wr
@@ -419,8 +414,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def update(q: DBObject, o: DBObject, upsert: Boolean = false, multi: Boolean = false, wc: WriteConcern = defaultWriteConcern): WriteResult = {
     val wr = collection.update(decorateQuery(q), o, upsert, multi, wc)
-    val lastError = wr.getCachedLastError
-    if (lastError != null && !lastError.ok()) {
+    if (wr.wasAcknowledged()) {
       throw SalatDAOUpdateError(description, collection, q, o, wc, wr, upsert, multi)
     }
     wr

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatMongoCursor.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatMongoCursor.scala
@@ -107,11 +107,11 @@ trait SalatMongoCursorBase[T <: AnyRef] extends Logging {
     this
   }
 
-  def numGetMores = underlying.numGetMores
+  // TODO migration: removed def numGetMores = underlying.numGetMores
 
   def numSeen = underlying.numSeen
 
-  def sizes = scala.collection.convert.Wrappers.JListWrapper(underlying.getSizes)
+  // TODO migration: removed def sizes = scala.collection.convert.Wrappers.JListWrapper(underlying.getSizes)
 
   def batchSize(n: Int) = {
     underlying.batchSize(n)

--- a/salat-core/src/test/scala/com/novus/salat/test/GraterSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/GraterSpec.scala
@@ -157,7 +157,13 @@ class GraterSpec extends SalatSpec {
         //        theOrder must_== order
         todo
       }
+
+      "initialize empty _id with default 'None' if type Option" in {
+        grater[ProbeOptionalId].fromJSON("{}")._id should beNone
+      }
     }
   }
 
 }
+
+case class ProbeOptionalId(_id: Option[ObjectId] = None)

--- a/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/MapSupportSpec.scala
@@ -70,7 +70,7 @@ class MapSupportSpec extends SalatSpec {
       val coll = MongoConnection()(SalatSpecDb)("map_support_test_1")
       val wr = coll.insert(dbo)
       //      log.info("WR: %s", wr)
-      wr.getCachedLastError must beNull
+      wr.wasAcknowledged() must beTrue
 
       val ao_* = grater[AttributeObject].asObject(coll.findOne().get)
       ao_* must_== ao


### PR DESCRIPTION
Not sure if this should even be supported, but my PR contains a test that demonstrates that the Grater will not use None when deserializing a class that has an optional id (and is not set).

It results in an error:

```
Grater error: clazz='class com.novus.salat.test.ProbeOptionalId' field '_id' needs to register presence or absence of default values  (Grater.scala:421)
```

Please note that this is a regression from the fixes in #130 / #137 and has worked with 1.9.8 but fails with both 1.9.9 and 2.0.0-SNAPSHOT
