### PR TITLE
Casbah 2.8.2 upgrade - leverage MongoException while supporting legacy error handling.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ See also: [Contributing to Open Source on GitHub](https://guides.github.com/acti
 Getting up to develop Salat requires three high-level steps
 
 1. Install SBT (recommended: sbt: the rebel cut: https://github.com/paulp/sbt-extras)
-2. Install MongoDB (this is required for unit tests): https://docs.mongodb.com/v2.6/installation/
+2. Install the appropriate MongoDB version (this is required for unit tests): https://docs.mongodb.com/manual/installation/
 3. `sbt test:test` to ensure the project compiles and all unit tests pass.
 
 # Which Version/Branch?

--- a/notes/1.10.0.markdown
+++ b/notes/1.10.0.markdown
@@ -2,8 +2,16 @@
 
 1.10.0 is a major release of Salat with breaking changes.
 
-Noteably, the package has changed from `com.novus.salat._` to `salat._`
+Notably, the package has changed from `com.novus.salat._` to `salat._`
 
-Additional changes:
+# Change Log
 
-- #145 Upgrade to Casbah 2.8
+- \#145 Upgrade to Casbah 2.8.2
+
+# Compatibility
+
+- If you create a `SalatDAO` using a collection created from a `MongoClient`, its methods may throw a `SalatDAOError` having a `MongoException` root cause. `SalatDAOError` now extends `RuntimeException` instead of `java.lang.Error`, and the constructor signature has changed accordingly.
+
+- A `SalatDAO` created using a `MongoCollection` from a `MongoConnection` will attempt attempt to detect errors from the `WriteResult`, but is not guaranteed (from the Mongo 3.x upgrade notes: "[getLastError] does not work reliably in the 2.x series and there is no way to make it work reliably" - http://mongodb.github.io/mongo-java-driver/3.0/whats-new/upgrading/). Be sure to use `MongoClient`.
+
+

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -256,7 +256,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Remove documents matching parent id
-     *
      *  @param parentId parent id
      *  @param wc write concern
      */
@@ -266,7 +265,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Remove documents matching parent ids
-     *
      *  @param parentIds parent ids
      *  @param wc write concern
      */
@@ -276,7 +274,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Projection typed to a case class, trait or abstract superclass.
-     *
      *  @param parentId parent id
      *  @param field field to project on
      *  @param query (optional) object for which to search
@@ -291,7 +288,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Projection typed to a case class, trait or abstract superclass.
-     *
      *  @param parentIds parent ids
      *  @param field field to project on
      *  @param query (optional) object for which to search
@@ -306,7 +302,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Projection typed to a type for which Casbah or mongo-java-driver handles conversion
-     *
      *  @param parentId parent id
      *  @param field field to project on
      *  @param query (optional) object for which to search
@@ -321,7 +316,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
 
     /**
      * Projection typed to a type for which Casbah or mongo-java-driver handles conversion
-     *
      *  @param parentIds parent ids
      *  @param field field to project on
      *  @param query (optional) object for which to search

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -348,10 +348,8 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def insert(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
-    var wr: WriteResult = null
-
     try {
-      wr = collection.insert(dbo, wc)
+      val wr = collection.insert(dbo, wc)
       handleLegacyErrors(wr) {
         throw SalatInsertError(description, collection, wc, wr, List(dbo))
       } {
@@ -360,7 +358,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
     }
     catch {
       case mex: MongoException =>
-        throw SalatInsertError(description, collection, wc, MongoErrorAdapter(wr, Option(mex)), List(dbo))
+        throw SalatInsertError(description, collection, wc, Right(mex), List(dbo))
     }
   }
 
@@ -372,10 +370,8 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def insert(docs: Traversable[ObjectType], wc: WriteConcern = defaultWriteConcern) = if (docs.nonEmpty) {
     val dbos = docs.map(decorateDBO(_)).toList
-    var wr: WriteResult = null
-
     try {
-      wr = collection.insert(dbos: _*)
+      val wr = collection.insert(dbos: _*)
       handleLegacyErrors(wr) {
         throw SalatInsertError(description, collection, wc, wr, dbos)
       } {
@@ -386,7 +382,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
       }
     }
     catch {
-      case mex: MongoException => throw SalatInsertError(description, collection, wc, MongoErrorAdapter(wr, Option(mex)), dbos)
+      case mex: MongoException => throw SalatInsertError(description, collection, wc, Right(mex), dbos)
     }
   }
   else Nil
@@ -421,9 +417,8 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def remove(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
-    var wr: WriteResult = null
     try {
-      wr = collection.remove(dbo, wc)
+      val wr = collection.remove(dbo, wc)
 
       handleLegacyErrors(wr) {
         throw SalatRemoveError(description, collection, wc, wr, List(dbo))
@@ -433,7 +428,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
     }
     catch {
       case mex: MongoException =>
-        throw SalatRemoveError(description, collection, wc, MongoErrorAdapter(wr, Option(mex)), List(dbo))
+        throw SalatRemoveError(description, collection, wc, Right(mex), List(dbo))
     }
   }
 
@@ -443,9 +438,8 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    *  @return (WriteResult) result of write operation
    */
   def remove[A <% DBObject](q: A, wc: WriteConcern) = {
-    var wr: WriteResult = null
     try {
-      wr = collection.remove(q, wc)
+      val wr = collection.remove(q, wc)
 
       handleLegacyErrors(wr) {
         throw SalatRemoveQueryError(description, collection, q, wc, wr)
@@ -455,7 +449,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
     }
     catch {
       case mex: MongoException =>
-        throw SalatRemoveQueryError(description, collection, q, wc, MongoErrorAdapter(wr, Option(mex)))
+        throw SalatRemoveQueryError(description, collection, q, wc, Right(mex))
     }
   }
 
@@ -484,10 +478,9 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def save(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
-    var wr: WriteResult = null
 
     try {
-      wr = collection.save(dbo, wc)
+      val wr = collection.save(dbo, wc)
 
       handleLegacyErrors(wr) {
         throw SalatSaveError(description, collection, wc, wr, List(dbo))
@@ -496,7 +489,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
       }
     }
     catch {
-      case mex: MongoException => throw SalatSaveError(description, collection, wc, MongoErrorAdapter(wr, Option(mex)), List(dbo))
+      case mex: MongoException => throw SalatSaveError(description, collection, wc, Right(mex), List(dbo))
     }
   }
 
@@ -509,7 +502,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    *  @return (WriteResult) result of write operation
    */
   def update(q: DBObject, o: DBObject, upsert: Boolean = false, multi: Boolean = false, wc: WriteConcern = defaultWriteConcern): WriteResult = {
-    var wr: WriteResult = null
     try {
       val wr = collection.update(decorateQuery(q), o, upsert, multi, wc)
 
@@ -521,7 +513,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
     }
     catch {
       case mex: MongoException =>
-        throw SalatDAOUpdateError(description, collection, q, o, wc, MongoErrorAdapter(wr, Option(mex)), upsert, multi)
+        throw SalatDAOUpdateError(description, collection, q, o, wc, Right(mex), upsert, multi)
     }
   }
 

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAOErrors.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAOErrors.scala
@@ -31,9 +31,9 @@ import com.mongodb.casbah.TypeImports._
 import com.mongodb.{DBObject, WriteConcern}
 
 protected[dao] object SalatDAOError {
-  type SalatDAOMongoError = Either[WriteResult, MongoException]
+  type LegacyErrorOrMongoException = Either[WriteResult, MongoException]
 
-  implicit class SomeKindOfMongoError(val cause: SalatDAOMongoError) extends AnyVal {
+  implicit class SomeKindOfMongoError(val cause: LegacyErrorOrMongoException) extends AnyVal {
     def toErrorString: String = cause.fold({ wr => s"$wr" }, { ex => s"$ex" })
   }
 
@@ -55,7 +55,7 @@ abstract class SalatDAOError(
   thingThatFailed: String,
   collection:      MongoCollection,
   wc:              WriteConcern,
-  cause:           SalatDAOMongoError,
+  cause:           LegacyErrorOrMongoException,
   dbos:            List[DBObject]
 ) extends RuntimeException(s"""
 
@@ -69,7 +69,7 @@ abstract class SalatDAOError(
  """, cause.right.toOption.orNull)
 
 object SalatInsertError {
-  @deprecated("Use MongoClient instead of MongoCollection", "1.10.0")
+  @deprecated("Use MongoClient instead of MongoConnection", "1.10.0")
   def apply(
     description: String,
     collection:  MongoCollection,
@@ -84,12 +84,12 @@ case class SalatInsertError(
   description: String,
   collection:  MongoCollection,
   wc:          WriteConcern,
-  cause:       SalatDAOMongoError,
+  cause:       LegacyErrorOrMongoException,
   dbos:        List[DBObject]
 ) extends SalatDAOError(description, "insert", collection, wc, cause, dbos)
 
 object SalatRemoveError {
-  @deprecated("Use MongoClient instead of MongoCollection", "1.10.0")
+  @deprecated("Use MongoClient instead of MongoConnection", "1.10.0")
   def apply(
     description: String,
     collection:  MongoCollection,
@@ -104,12 +104,12 @@ case class SalatRemoveError(
   description: String,
   collection:  MongoCollection,
   wc:          WriteConcern,
-  cause:       SalatDAOMongoError,
+  cause:       LegacyErrorOrMongoException,
   dbos:        List[DBObject]
 ) extends SalatDAOError(description, "remove", collection, wc, cause, dbos)
 
 object SalatSaveError {
-  @deprecated("Use MongoClient instead of MongoCollection", "1.10.0")
+  @deprecated("Use MongoClient instead of MongoConnection", "1.10.0")
   def apply(
     description: String,
     collection:  MongoCollection,
@@ -124,7 +124,7 @@ case class SalatSaveError(
   description: String,
   collection:  MongoCollection,
   wc:          WriteConcern,
-  cause:       SalatDAOMongoError,
+  cause:       LegacyErrorOrMongoException,
   dbos:        List[DBObject]
 ) extends SalatDAOError(description, "save", collection, wc, cause, dbos)
 
@@ -134,7 +134,7 @@ abstract class SalatDAOQueryError(
   collection:      MongoCollection,
   query:           DBObject,
   wc:              WriteConcern,
-  cause:           SalatDAOMongoError
+  cause:           LegacyErrorOrMongoException
 ) extends RuntimeException(s"""
 
     $whichDAO: $thingThatFailed failed!
@@ -164,7 +164,7 @@ case class SalatRemoveQueryError(
   collection: MongoCollection,
   query:      DBObject,
   wc:         WriteConcern,
-  cause:      SalatDAOMongoError
+  cause:      LegacyErrorOrMongoException
 ) extends SalatDAOQueryError(whichDAO, "remove", collection, query, wc, cause)
 
 object SalatDAOUpdateError {
@@ -188,7 +188,7 @@ case class SalatDAOUpdateError(
   query:      DBObject,
   o:          DBObject,
   wc:         WriteConcern,
-  cause:      SalatDAOMongoError,
+  cause:      LegacyErrorOrMongoException,
   upsert:     Boolean,
   multi:      Boolean
 ) extends RuntimeException(s"""

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/AlphaDAO.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/AlphaDAO.scala
@@ -50,7 +50,7 @@ case class Alpha(@Key("_id") id: Int, beta: List[Beta] = Nil)
 //
 object AlphaDAO extends SalatDAO[Alpha, Int](collection = MongoClient()(SalatSpecDb)(AlphaColl))
 
-/** Uses MongoCollection, and so won't throw MongoException */
+/** Uses MongoConnection (deprecated) instead of MongoClient, and so won't throw MongoException on errors. */
 object DeprecatedAlphaDAO extends SalatDAO[Alpha, Int](collection = MongoConnection()(SalatSpecDb)(AlphaColl))
 
 case class Epsilon(@Key("_id") id: ObjectId = new ObjectId, notes: String)

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/AlphaDAO.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/AlphaDAO.scala
@@ -48,22 +48,25 @@ case class Alpha(@Key("_id") id: Int, beta: List[Beta] = Nil)
 // 2.  define a grater for the class
 // 3.  specify a collection
 //
-object AlphaDAO extends SalatDAO[Alpha, Int](collection = MongoConnection()(SalatSpecDb)(AlphaColl))
+object AlphaDAO extends SalatDAO[Alpha, Int](collection = MongoClient()(SalatSpecDb)(AlphaColl))
+
+/** Uses MongoCollection, and so won't throw MongoException */
+object DeprecatedAlphaDAO extends SalatDAO[Alpha, Int](collection = MongoConnection()(SalatSpecDb)(AlphaColl))
 
 case class Epsilon(@Key("_id") id: ObjectId = new ObjectId, notes: String)
 
-object EpsilonDAO extends SalatDAO[Epsilon, ObjectId](collection = MongoConnection()(SalatSpecDb)(EpsilonColl))
+object EpsilonDAO extends SalatDAO[Epsilon, ObjectId](collection = MongoClient()(SalatSpecDb)(EpsilonColl))
 
 case class Theta(@Key("_id") id: ObjectId = new ObjectId, x: String, y: String)
 case class Xi(@Key("_id") id: ObjectId = new ObjectId, x: String, y: Option[String])
 case class Nu(x: String, y: String)
 case class Kappa(@Key("_id") id: ObjectId = new ObjectId, k: String, nu: Nu)
 
-object ThetaDAO extends SalatDAO[Theta, ObjectId](collection = MongoConnection()(SalatSpecDb)(ThetaColl))
+object ThetaDAO extends SalatDAO[Theta, ObjectId](collection = MongoClient()(SalatSpecDb)(ThetaColl))
 
-object XiDAO extends SalatDAO[Xi, ObjectId](collection = MongoConnection()(SalatSpecDb)(XiColl))
+object XiDAO extends SalatDAO[Xi, ObjectId](collection = MongoClient()(SalatSpecDb)(XiColl))
 
-object KappaDAO extends SalatDAO[Kappa, ObjectId](collection = MongoConnection()(SalatSpecDb)(KappaColl))
+object KappaDAO extends SalatDAO[Kappa, ObjectId](collection = MongoClient()(SalatSpecDb)(KappaColl))
 
 case class ChildInfo(lastUpdated: DateTime = new DateMidnight(0L).toDateTime)
 case class Child(
@@ -75,10 +78,10 @@ case class Child(
 )
 case class Parent(@Key("_id") id: ObjectId = new ObjectId, name: String)
 
-object ParentDAO extends SalatDAO[Parent, ObjectId](collection = MongoConnection()(SalatSpecDb)(ParentColl)) {
+object ParentDAO extends SalatDAO[Parent, ObjectId](collection = MongoClient()(SalatSpecDb)(ParentColl)) {
 
   val children = new ChildCollection[Child, Int](
-    collection    = MongoConnection()(SalatSpecDb)(ChildColl),
+    collection    = MongoClient()(SalatSpecDb)(ChildColl),
     parentIdField = "parentId"
   ) {}
 
@@ -95,9 +98,9 @@ case class Author(_id: ObjectId = new ObjectId, userId: ObjectId) extends Role
 case class Editor(_id: ObjectId = new ObjectId, userId: ObjectId) extends Role
 case class Admin(_id: ObjectId = new ObjectId, userId: ObjectId) extends Role
 
-object UserDAO extends SalatDAO[User, ObjectId](collection = MongoConnection()(SalatSpecDb)(UserColl)) {
+object UserDAO extends SalatDAO[User, ObjectId](collection = MongoClient()(SalatSpecDb)(UserColl)) {
   val roles = new ChildCollection[Role, ObjectId](
-    collection    = MongoConnection()(SalatSpecDb)(RoleColl),
+    collection    = MongoClient()(SalatSpecDb)(RoleColl),
     parentIdField = "userId"
   ) {}
 

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
@@ -94,14 +94,14 @@ class SalatDAOSpec extends SalatSpec {
       AlphaDAO.insert() must_== Nil
     }
 
-    "handle MongoExceptions due to inserting records having duplicate keys" in new alphaContext {
+    "handle MongoExceptions when inserting an object having a duplicate key" in new alphaContext {
       AlphaDAO.insert(alpha7)
       AlphaDAO.insert(alpha7) must throwA[SalatInsertError].like {
         case ex: SalatInsertError => ex.getCause must beAnInstanceOf[DuplicateKeyException]
       }
     }
 
-    "handle MongoExceptions for bulk inserts having a duplicate key" in new alphaContext {
+    "handle MongoExceptions for bulk inserts where an object has a duplicate key" in new alphaContext {
       AlphaDAO.insert(alpha7)
 
       // Note: Mongo stops processing at the first dup in the list
@@ -114,12 +114,12 @@ class SalatDAOSpec extends SalatSpec {
       }
     }
 
-    "handle legacy errors due to inserting records having duplicate keys" in new alphaContext {
+    "handle legacy errors when inserting an object having a duplicate key" in new alphaContext {
       DeprecatedAlphaDAO.insert(alpha7)
       DeprecatedAlphaDAO.insert(alpha7) must throwA[SalatInsertError]
     }
 
-    "handle legacy errors for bulk inserts having a duplicate key" in new alphaContext {
+    "handle legacy errors for bulk inserts where an object has a duplicate key" in new alphaContext {
       DeprecatedAlphaDAO.insert(alpha7)
 
       // Note: Mongo stops processing at the first dup in the list
@@ -137,7 +137,7 @@ class SalatDAOSpec extends SalatSpec {
       }
     }
 
-    "handle legacy for invalid updates" in new alphaContext {
+    "handle legacy errors for invalid updates" in new alphaContext {
       DeprecatedAlphaDAO.insert(alpha7)
       DeprecatedAlphaDAO.update(MongoDBObject.empty, MongoDBObject("_id" -> 1)) must throwA[SalatDAOUpdateError]
     }

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
@@ -102,8 +102,8 @@ class SalatDAOSpec extends SalatSpec {
 
     "handle DAOs using deprecated MongoConnection, throwing an exception on a WriteResult error" in new alphaContext {
       DeprecatedAlphaDAO.insert(alpha7)
-      AlphaDAO.insert(alpha7) must throwA[SalatInsertError]
-    }
+      DeprecatedAlphaDAO.insert(alpha7) must throwA[SalatInsertError]
+    }.pendingUntilFixed("duplicate insert fails silently when SalatDAO uses a MongoConnection instead of a MongoClient?!?")
 
     "support findOne returning Option[T]" in new alphaContext {
       val _ids = AlphaDAO.insert(alpha4, alpha5, alpha6)

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
@@ -307,29 +307,29 @@ class SalatDAOSpec extends SalatSpec {
   trait alphaContext extends Scope {
     log.debug("before: dropping %s", AlphaDAO.collection.fullName)
     AlphaDAO.collection.drop()
-    AlphaDAO.collection.count() must_== 0L
+    AlphaDAO.collection.isEmpty aka "alpha collection must be empty before test" must beTrue
   }
 
   trait alphaContextWithData extends Scope {
     log.debug("before: dropping %s", AlphaDAO.collection.fullName)
     AlphaDAO.collection.drop()
-    AlphaDAO.collection.count() must_== 0L
+    AlphaDAO.collection.isEmpty aka "alpha collection must be empty before test" must beTrue
 
     val _ids = AlphaDAO.insert(alpha1, alpha2, alpha3, alpha4, alpha5, alpha6)
     _ids must contain(Option(alpha1.id), Option(alpha2.id), Option(alpha3.id), Option(alpha4.id), Option(alpha5.id), Option(alpha6.id))
-    AlphaDAO.collection.count() must_== 6L
+    AlphaDAO.collection.count() aka "alpha collection must have 6 records before test" must_== 6L
   }
 
   trait epsilonContext extends Scope {
     log.debug("before: dropping %s", EpsilonDAO.collection.fullName)
     EpsilonDAO.collection.drop()
-    EpsilonDAO.collection.count() must_== 0L
+    EpsilonDAO.collection.isEmpty aka "epsilon collection must be empty before test" must beTrue
   }
 
   trait thetaContext extends Scope {
     log.debug("before: dropping %s", ThetaDAO.collection.fullName)
     ThetaDAO.collection.drop()
-    ThetaDAO.collection.count() must_== 0L
+    ThetaDAO.collection.isEmpty aka "theta collection must be empty before test" must beTrue
 
     val theta1 = Theta(x = "x1", y = "y1")
     val theta2 = Theta(x = "x2", y = "y2")
@@ -338,13 +338,13 @@ class SalatDAOSpec extends SalatSpec {
     val theta5 = Theta(x = "x5", y = null)
     val _ids = ThetaDAO.insert(theta1, theta2, theta3, theta4, theta5)
     _ids must contain(Option(theta1.id), Option(theta2.id), Option(theta3.id), Option(theta4.id), Option(theta5.id))
-    ThetaDAO.collection.count() must_== 5L
+    ThetaDAO.collection.count() aka "theta collection must have 5 records before test" must_== 5L
   }
 
   trait xiContext extends Scope {
     log.debug("before: dropping %s", XiDAO.collection.fullName)
     XiDAO.collection.drop()
-    XiDAO.collection.count() must_== 0L
+    XiDAO.collection.isEmpty aka "xi collection must be empty before test" must beTrue
 
     val xi1 = Xi(x = "x1", y = Some("y1"))
     val xi2 = Xi(x = "x2", y = Some("y2"))
@@ -353,13 +353,13 @@ class SalatDAOSpec extends SalatSpec {
     val xi5 = Xi(x = "x5", y = None)
     val _ids = XiDAO.insert(xi1, xi2, xi3, xi4, xi5)
     _ids must contain(Option(xi1.id), Option(xi2.id), Option(xi3.id), Option(xi4.id), Option(xi5.id))
-    XiDAO.collection.count() must_== 5L
+    XiDAO.collection.count() aka "xi collection must have 5 records before test" must_== 5L
   }
 
   trait kappaContext extends Scope {
     log.debug("before: dropping %s", KappaDAO.collection.fullName)
     KappaDAO.collection.drop()
-    KappaDAO.collection.count() must_== 0L
+    KappaDAO.collection.isEmpty aka "kappa collection must be empty before test" must beTrue
 
     val nu1 = Nu(x = "x1", y = "y1")
     val nu2 = Nu(x = "x2", y = "y2")
@@ -370,6 +370,6 @@ class SalatDAOSpec extends SalatSpec {
     val kappa3 = Kappa(k = "k3", nu = nu3)
     val _ids = KappaDAO.insert(kappa1, kappa2, kappa3)
     _ids must contain(Option(kappa1.id), Option(kappa2.id), Option(kappa3.id))
-    KappaDAO.collection.count() must_== 3L
+    KappaDAO.collection.count() aka "kappa collection must have 3 records before test" must_== 3L
   }
 }

--- a/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/dao/SalatDAOSpec.scala
@@ -41,6 +41,7 @@ class SalatDAOSpec extends SalatSpec {
   // which most specs can execute concurrently, this particular spec needs to execute sequentially to avoid mutating shared state,
   // namely, the MongoDB collection referenced by the AlphaDAO
   sequential
+  isolated
 
   implicit val wc = AlphaDAO.defaultWriteConcern
 


### PR DESCRIPTION
@sief please check this alternative to #168. I added support for error handling via `MongoException` while providing some semblance of support for old code that relies on the debugging added by `SalatDAOError`s as well as code that uses `MongoConnection` (which I found - being a deprecated class - creates connections that do _not_ throw `MongoException` at all - you have to check last error!).
