### PR TITLE
[1.10.x] Issue #115 findAndModify methods

### DIFF
--- a/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
@@ -195,6 +195,39 @@ trait BaseDAOMethods[ObjectType <: AnyRef, ID <: Any] {
   }
 
   /**
+   * Performs a find and update operation.
+   * @param q search query to find and modify
+   * @param o object with which to modify <tt>q</tt>
+   *  @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
+   */
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType]
+
+  /**
+   * Finds the first document in the query (sorted) and updates it.
+   * @param q query to match
+   * @param sort sort to apply before picking first document
+   * @param o object with which to modify <tt>q</tt>
+   *
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType]
+
+  /**
+   * Finds the first document in the query and updates it.
+   *
+   * @param q query to match
+   * @param fields fields to be returned
+   * @param sort sort to apply before picking first document
+   * @param remove if true, document found will be removed
+   * @param o object with which to modify <tt>q</tt>
+   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
+   * @param upsert do upsert (insert if document not present)
+   *
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType]
+
+  /**
    * Remove a matching object from the collection
    *  @param t object to remove from the collection
    *  @return (WriteResult) result of write operation

--- a/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/DAO.scala
@@ -197,35 +197,20 @@ trait BaseDAOMethods[ObjectType <: AnyRef, ID <: Any] {
   /**
    * Performs a find and update operation.
    * @param q search query to find and modify
-   * @param o object with which to modify <tt>q</tt>
+   * @param t object with which to modify <tt>q</tt>
    *  @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
    */
-  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType]
+  def findAndModify[A <% DBObject](q: A, t: ObjectType): Option[ObjectType]
 
   /**
    * Finds the first document in the query (sorted) and updates it.
    * @param q query to match
    * @param sort sort to apply before picking first document
-   * @param o object with which to modify <tt>q</tt>
+   * @param t object with which to modify <tt>q</tt>
    *
    * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
    */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType]
-
-  /**
-   * Finds the first document in the query and updates it.
-   *
-   * @param q query to match
-   * @param fields fields to be returned
-   * @param sort sort to apply before picking first document
-   * @param remove if true, document found will be removed
-   * @param o object with which to modify <tt>q</tt>
-   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
-   * @param upsert do upsert (insert if document not present)
-   *
-   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
-   */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType]
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, sort: B, t: ObjectType): Option[ObjectType]
 
   /**
    * Remove a matching object from the collection

--- a/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
@@ -335,36 +335,22 @@ trait ModelCompanion[ObjectType <: AnyRef, ID <: Any] extends BaseDAOMethods[Obj
    * Performs a find and update operation.
    *
    * @param q search query to find and modify
-   * @param o object with which to modify <tt>q</tt>
+   * @param t object with which to modify <tt>q</tt>
    * @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
    */
-  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType] =
-    dao.findAndModify(q, o)
+  def findAndModify[A <% DBObject](q: A, t: ObjectType): Option[ObjectType] =
+    dao.findAndModify(q, t)
 
   /**
    * Finds the first document in the query (sorted) and updates it.
    *
    * @param q    query to match
    * @param sort sort to apply before picking first document
-   * @param o    object with which to modify <tt>q</tt>
+   * @param t    object with which to modify <tt>q</tt>
    * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
    */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType] =
-    dao.findAndModify(q, sort, o)
-
-  /**
-   * Finds the first document in the query and updates it.
-   *
-   * @param q         query to match
-   * @param fields    fields to be returned
-   * @param sort      sort to apply before picking first document
-   * @param remove    if true, document found will be removed
-   * @param o         object with which to modify <tt>q</tt>
-   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
-   * @param upsert    do upsert (insert if document not present)
-   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
-   */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType] = dao.findAndModify(q, fields, sort, remove, o, returnNew, upsert)
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, sort: B, t: ObjectType): Option[ObjectType] =
+    dao.findAndModify(q, sort, t)
 
   //
   // methods I can't see the point of personally, but which pay some distant obeisance to the Platonic DAO carried

--- a/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/ModelCompanion.scala
@@ -63,12 +63,14 @@ trait ModelCompanion[ObjectType <: AnyRef, ID <: Any] extends BaseDAOMethods[Obj
 
   /**
    * In the absence of a specified write concern, supplies a default write concern.
+   *
    *  @return default write concern to use for insert, update, save and remove operations
    */
   def defaultWriteConcern = dao.defaultWriteConcern
 
   /**
    * In the absence of a specified read preference, supplies a default read preference.
+   *
    *  @return default read preference for all find and count operations.
    */
   def defaultReadPreference = dao.defaultReadPreference
@@ -171,6 +173,7 @@ trait ModelCompanion[ObjectType <: AnyRef, ID <: Any] extends BaseDAOMethods[Obj
 
   /**
    * Count the number of documents matching the search criteria.
+   *
    *  @param q object for which to search
    *  @param fieldsThatMustExist list of field keys that must exist
    *  @param fieldsThatMustNotExist list of field keys that must not exist
@@ -327,6 +330,41 @@ trait ModelCompanion[ObjectType <: AnyRef, ID <: Any] extends BaseDAOMethods[Obj
   def update(q: DBObject, o: DBObject, upsert: Boolean, multi: Boolean, wc: WriteConcern = defaultWriteConcern) = {
     dao.update(q, o, upsert, multi, wc)
   }
+
+  /**
+   * Performs a find and update operation.
+   *
+   * @param q search query to find and modify
+   * @param o object with which to modify <tt>q</tt>
+   * @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
+   */
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType] =
+    dao.findAndModify(q, o)
+
+  /**
+   * Finds the first document in the query (sorted) and updates it.
+   *
+   * @param q    query to match
+   * @param sort sort to apply before picking first document
+   * @param o    object with which to modify <tt>q</tt>
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType] =
+    dao.findAndModify(q, sort, o)
+
+  /**
+   * Finds the first document in the query and updates it.
+   *
+   * @param q         query to match
+   * @param fields    fields to be returned
+   * @param sort      sort to apply before picking first document
+   * @param remove    if true, document found will be removed
+   * @param o         object with which to modify <tt>q</tt>
+   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
+   * @param upsert    do upsert (insert if document not present)
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType] = dao.findAndModify(q, fields, sort, remove, o, returnNew, upsert)
 
   //
   // methods I can't see the point of personally, but which pay some distant obeisance to the Platonic DAO carried

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -529,38 +529,22 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   /**
    * Performs a find and update operation.
    * @param q search query to find and modify
-   * @param o object with which to modify <tt>q</tt>
+   * @param t object with which to modify <tt>q</tt>
    *  @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
    */
-  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType] =
-    collection.findAndModify(q, o).map(_grater.asObject(_))
+  def findAndModify[A <% DBObject](q: A, t: ObjectType): Option[ObjectType] =
+    collection.findAndModify(q, toDBObject(t)).map(_grater.asObject(_))
 
   /**
    * Finds the first document in the query (sorted) and updates it.
    * @param q query to match
    * @param sort sort to apply before picking first document
-   * @param o object with which to modify <tt>q</tt>
+   * @param t object with which to modify <tt>q</tt>
    *
    * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
    */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType] =
-    collection.findAndModify(q, sort, o).map(_grater.asObject(_))
-
-  /**
-   * Finds the first document in the query and updates it.
-   *
-   * @param q query to match
-   * @param fields fields to be returned
-   * @param sort sort to apply before picking first document
-   * @param remove if true, document found will be removed
-   * @param o object with which to modify <tt>q</tt>
-   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
-   * @param upsert do upsert (insert if document not present)
-   *
-   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
-   */
-  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType] =
-    collection.findAndModify(q, fields, sort, remove, o, returnNew, upsert).map(_grater.asObject(_))
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, sort: B, t: ObjectType): Option[ObjectType] =
+    collection.findAndModify(q, sort, toDBObject(t)).map(_grater.asObject(_))
 
   /**
    * @param ref object for which to search

--- a/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/com/novus/salat/dao/SalatDAO.scala
@@ -527,6 +527,42 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   }
 
   /**
+   * Performs a find and update operation.
+   * @param q search query to find and modify
+   * @param o object with which to modify <tt>q</tt>
+   *  @return (Option[ObjectType]) Some() of the object found (before, or after, the update)
+   */
+  def findAndModify[A <% DBObject, B <% DBObject](q: A, o: B): Option[ObjectType] =
+    collection.findAndModify(q, o).map(_grater.asObject(_))
+
+  /**
+   * Finds the first document in the query (sorted) and updates it.
+   * @param q query to match
+   * @param sort sort to apply before picking first document
+   * @param o object with which to modify <tt>q</tt>
+   *
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject](q: A, sort: B, o: C): Option[ObjectType] =
+    collection.findAndModify(q, sort, o).map(_grater.asObject(_))
+
+  /**
+   * Finds the first document in the query and updates it.
+   *
+   * @param q query to match
+   * @param fields fields to be returned
+   * @param sort sort to apply before picking first document
+   * @param remove if true, document found will be removed
+   * @param o object with which to modify <tt>q</tt>
+   * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
+   * @param upsert do upsert (insert if document not present)
+   *
+   * @return (Option[ObjectType]) Some() of the old document, or <code>None</code> if no such object exists
+   */
+  def findAndModify[A <% DBObject, B <% DBObject, C <% DBObject, D <% DBObject](q: A, fields: B, sort: C, remove: Boolean, o: D, returnNew: Boolean, upsert: Boolean): Option[ObjectType] =
+    collection.findAndModify(q, fields, sort, remove, o, returnNew, upsert).map(_grater.asObject(_))
+
+  /**
    * @param ref object for which to search
    *  @param keys fields to return
    *  @param rp sets the desired ReadPreference on the cursor


### PR DESCRIPTION
@ysukhoverkhov here is a PR that implements findAndModify for SalatDAO.

I implemented the two simplest versions - with just query + document, and then query + sort + document. The more advanced versions with upsert, returnNew, etc. didn't seem to be appropriate for simple orm operations.

Please provide feedback - I will merge and publish a snapshot in the next few days.
