### PR TITLE
[1.10.x] Log more errors in case of known deserialization problems (#143)

### DIFF
--- a/notes/1.10.0.markdown
+++ b/notes/1.10.0.markdown
@@ -8,6 +8,7 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 ## Features
 
+- \#143 Log more error details in case of deserialization problem (@noahlz, @slorber)
 - \#145 Upgrade to Casbah 2.8.2 (@danslapman, @sief, @noahlz)
 - \#155 Improve support for binary data such as `Seq[Byte]` in case classes. (@glorat)
 - \#171 Support `Map[String, Any]`, `List[Any], Option[Any]` (@dieu, @noahlz)

--- a/notes/1.10.0.markdown
+++ b/notes/1.10.0.markdown
@@ -6,14 +6,17 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 # Change Log
 
+## Upgrades
+
+- \#145 Upgrade to Casbah 2.8.2 (@danslapman, @sief, @noahlz)
+
 ## Features
 
+- \#115 Add `findAndModify` to BaseDAOMethods (@noahlz)
 - \#143 Log more error details in case of deserialization problem (@noahlz, @slorber)
-- \#145 Upgrade to Casbah 2.8.2 (@danslapman, @sief, @noahlz)
 - \#155 Improve support for binary data such as `Seq[Byte]` in case classes. (@glorat)
 - \#171 Support `Map[String, Any]`, `List[Any], Option[Any]` (@dieu, @noahlz)
 - \#173 Improve error message for `Map[String, List[_]` de-serialization error. (@noahlz)
-- \#115 Add `findAndModify` to BaseDAOMethods
 
 # Compatibility
 

--- a/notes/1.10.0.markdown
+++ b/notes/1.10.0.markdown
@@ -6,7 +6,7 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 # Change Log
 
-## Upgrades
+## Dependency Upgrades
 
 - \#145 Upgrade to Casbah 2.8.2 (@danslapman, @sief, @noahlz)
 
@@ -24,4 +24,5 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 - A `SalatDAO` created using a `MongoCollection` from a `MongoConnection` will attempt attempt to detect errors from the `WriteResult`, but is not guaranteed (from the Mongo 3.x upgrade notes: "[getLastError] does not work reliably in the 2.x series and there is no way to make it work reliably" - http://mongodb.github.io/mongo-java-driver/3.0/whats-new/upgrading/). Be sure to use `MongoClient`.
 
+- Introduced a new subclass of `Error`, `SalatGlitch`, that specifically identifies errors that occur during serialization / deserialization. Note that there are still many points in code that throw RuntimeException (via sys.error) - overhaul/normalization of Salat's errors remains an outstanding TODO.
 

--- a/salat-core/src/main/scala/com/novus/salat/Grater.scala
+++ b/salat-core/src/main/scala/com/novus/salat/Grater.scala
@@ -40,6 +40,7 @@ import org.json4s.native.JsonMethods._
 import org.json4s.native.JsonParser
 
 import scala.tools.scalap.scalax.rules.scalasig._
+import scala.util.control.NonFatal
 
 // TODO: create companion object to serve as factory for grater creation - there
 // is not reason for this logic to be wodged in Context
@@ -346,11 +347,12 @@ abstract class ConcreteGrater[X <: CaseClass](clazz: Class[X])(implicit ctx: Con
     catch {
       // when something bad happens feeding args into constructor, catch these exceptions and
       // wrap them in a custom exception that will provide detailed information about what's happening.
+      case e: SalatGlitch               => throw ToObjectGlitch(this, ca.sym, ca.constructor, args, e)
       case e: InstantiationException    => throw ToObjectGlitch(this, ca.sym, ca.constructor, args, e)
       case e: IllegalAccessException    => throw ToObjectGlitch(this, ca.sym, ca.constructor, args, e)
       case e: IllegalArgumentException  => throw ToObjectGlitch(this, ca.sym, ca.constructor, args, e)
       case e: InvocationTargetException => throw ToObjectGlitch(this, ca.sym, ca.constructor, args, e)
-      case e: Throwable                 => throw e
+      case NonFatal(e)                  => throw e
     }
   }
 

--- a/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
+++ b/salat-core/src/main/scala/com/novus/salat/transformers/inject/Injectors.scala
@@ -542,8 +542,14 @@ package in {
 
     val clazz = getClassNamed_!(path)
     val companion: Any = clazz.companionObject
-    val withName: Method = clazz.getDeclaredMethods.filter(_.getName == "withName").head
-    val applyInt: Method = clazz.getDeclaredMethods.filter(_.getName == "apply").head
+
+    val withName: Method = clazz.getDeclaredMethods.find(_.getName == "withName").getOrElse(
+      throw EnumInflaterCompanionObjectGlitch(clazz, "withName")
+    )
+
+    val applyInt: Method = clazz.getDeclaredMethods.find(_.getName == "apply").getOrElse(
+      throw EnumInflaterCompanionObjectGlitch(clazz, "apply")
+    )
 
     override def transform(value: Any)(implicit ctx: Context): Any = {
       val strategy = {

--- a/salat-core/src/main/scala/com/novus/salat/util/ToObjectGlitch.scala
+++ b/salat-core/src/main/scala/com/novus/salat/util/ToObjectGlitch.scala
@@ -52,8 +52,9 @@ case class ToObjectGlitch[X <: AnyRef with Product](grater: ConcreteGrater[X], s
   cause
 )
 
-case class GraterFromDboGlitch(path: String, dbo: MongoDBObject)(implicit ctx: Context) extends Error(MissingGraterExplanation(path, dbo)(ctx))
-case class GraterGlitch(path: String)(implicit ctx: Context) extends Error(MissingGraterExplanation(path)(ctx))
+case class GraterFromDboGlitch(path: String, dbo: MongoDBObject)(implicit ctx: Context) extends SalatGlitch(MissingGraterExplanation(path, dbo)(ctx))
+
+case class GraterGlitch(path: String)(implicit ctx: Context) extends SalatGlitch(MissingGraterExplanation(path)(ctx))
 
 object MissingTypeHint {
   def apply(x: Any): MissingTypeHint = x match {
@@ -75,6 +76,8 @@ case class MissingTypeHint(m: Map[_, _])(implicit ctx: Context) extends Error(""
 
  """.format(ctx.typeHintStrategy.typeHint, m.mkString("\n")))
 
-case class EnumInflaterGlitch(clazz: Class[_], strategy: EnumStrategy, value: Any) extends Error(
+case class EnumInflaterGlitch(clazz: Class[_], strategy: EnumStrategy, value: Any) extends SalatGlitch(
   "Not sure how to handle value='%s' as enum of class %s using strategy %s".format(value, clazz.getName, strategy)
 )
+
+case class EnumInflaterCompanionObjectGlitch(clazz: Class[_], missingMethod: String) extends SalatGlitch(s"required method '$missingMethod' missing from companion object for $clazz")

--- a/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
+++ b/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
@@ -33,7 +33,7 @@ import java.lang.reflect.Constructor
 /** A Salat transformation error that does not have an underlying cause. */
 class SalatGlitch(msg: String) extends Error(msg)
 
-// NOTE: There are places all over this codebase where we use sys.error (RuntimException) rather
+// NOTE: There are places all over this codebase where we use sys.error (RuntimeException) rather
 // than throwing a specific subclass of Error or RuntimeException. An outstanding cleanup TODO
 // (at risk of breaking production code in the wild) could be to normalize all these ad-hoc errors to
 // specific, actionable errors.

--- a/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
+++ b/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
@@ -29,8 +29,14 @@
 package com.novus.salat.util
 
 import java.lang.reflect.Constructor
-// a useful place to be when things go pear-shaped
-// p.s. could more people throw exceptions like these?
+
+/** A Salat transformation error that does not have an underlying cause. */
+class SalatGlitch(msg: String) extends Error(msg)
+
+// NOTE: There are places all over this codebase where we use sys.error (RuntimException) rather
+// than throwing a specific subclass of Error or RuntimeException. An outstanding cleanup TODO
+// (at risk of breaking production code in the wild) could be to normalize all these ad-hoc errors to
+// specific, actionable errors.
 
 /**
  * Runtime error indicating that a class defines more than one constructor with args.
@@ -38,7 +44,7 @@ import java.lang.reflect.Constructor
  *  @param cl list of parameterized constructors found for this class
  *  @tparam X any reft
  */
-case class TooManyConstructorsWithArgs[X](clazz: Class[X], cl: List[Constructor[X]]) extends Error(
+case class TooManyConstructorsWithArgs[X](clazz: Class[X], cl: List[Constructor[X]]) extends SalatGlitch(
   "constructor: clazz=%s ---> expected 1 constructor with args but found %d\n%s".format(clazz, cl.size, cl.mkString("\n"))
 )
 
@@ -46,25 +52,25 @@ case class TooManyConstructorsWithArgs[X](clazz: Class[X], cl: List[Constructor[
  * Runtime error indicating that Salat can't identify any constructor for this class.
  *  @param clazz class instance
  */
-case class MissingConstructor(clazz: Class[_]) extends Error("Couldn't find a constructor for %s".format(clazz.getName))
+case class MissingConstructor(clazz: Class[_]) extends SalatGlitch("Couldn't find a constructor for %s".format(clazz.getName))
 
 /**
  * Runtime error indicating that Salat can't find the pickled Scala signature for this class.
  *  @param clazz class instance
  */
-case class MissingPickledSig(clazz: Class[_]) extends Error("FAIL: class '%s' is missing both @ScalaSig and .class file!".format(clazz))
+case class MissingPickledSig(clazz: Class[_]) extends SalatGlitch("FAIL: class '%s' is missing both @ScalaSig and .class file!".format(clazz))
 
 /**
  * Runtime error indicating that class' pickled Scala signature does not define any top-level classes or objects.
  *  @param clazz class instance
  */
-case class MissingExpectedType(clazz: Class[_]) extends Error("Parsed pickled Scala signature, but no expected type found: %s"
+case class MissingExpectedType(clazz: Class[_]) extends SalatGlitch("Parsed pickled Scala signature, but no expected type found: %s"
   .format(clazz))
 
 //case class NestingGlitch(clazz: Class[_], owner: String, outer: String, inner: String) extends Error("Didn't find owner=%s, outer=%s, inner=%s in pickled scala sig for %s"
 //  .format(owner, outer, inner, clazz))
 
-case class MissingCaseObjectOverride(path: String, value: Any, ctxName: String) extends Error(
+case class MissingCaseObjectOverride(path: String, value: Any, ctxName: String) extends SalatGlitch(
   "Ctx='%s' does not define a case object override that can be used with class='%s' and value='%s'".
     format(ctxName, path, value)
 )


### PR DESCRIPTION
PR for #143 Log more errors for deserialization problems.

It turned out that the code to make this happen was already there in the form of `ToObjectGlitch` and the try/catch block of `feedArgsToConstructor` (as discussed in the issue). The problem was the existing try/catch wasn't catching errors thrown by Salat itself.

My strategy:
1) Define a Salat-specific subclass of `Error`: `SalatGlitch`
2) Have `feedArgsToConstructor` handle that error type
3) Add a new error for the stacktrace in the issue: `EnumInflaterCompanionObjectGlitch`. The existing code was throwing `None.get` (ugh).

I resisted the urge to completely overhaul Salat's error handling. Problems I see:

1) Why did we extend `Error` for most Salat-specific errors.  `RuntimeException` is more idiomatic for JVM errors (was this an early Scala convention?)

2) We throw `sys.error` all over the place, which generates fairly useless `RuntimeException`s (contradicting the aforementioned use of `java.lang.Error`, btw).

3) Probably more things have to be declared to be `SalatGlitch` errors.

4) It's not clear what the difference is between an "error" and a "Glitch" (does Glitch mean temporary error? In most cases, it appears to be due to programmer error) - but again, I'm just going with it, I don't want to start changing things around without reason.
