### PR TITLE
Issue #148 fail fast when deserializing from Double to Int and the conversion would lose information.

### DIFF
--- a/notes/1.10.0.markdown
+++ b/notes/1.10.0.markdown
@@ -12,8 +12,9 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 ## Features
 
-- \#115 Add `findAndModify` to BaseDAOMethods (@noahlz)
-- \#143 Log more error details in case of deserialization problem (@noahlz, @slorber)
+- \#115 Add `findAndModify` to BaseDAOMethods. (@noahlz)
+- \#143 Log more error details in case of deserialization problem. (@noahlz, @slorber)
+- \#148 Fail faster during deserialization when narrowing type conversion would lose information. (@noahlz)
 - \#155 Improve support for binary data such as `Seq[Byte]` in case classes. (@glorat)
 - \#171 Support `Map[String, Any]`, `List[Any], Option[Any]` (@dieu, @noahlz)
 - \#173 Improve error message for `Map[String, List[_]` de-serialization error. (@noahlz)
@@ -26,3 +27,4 @@ Notably, the package has changed from `com.novus.salat._` to `salat._`
 
 - Introduced a new subclass of `Error`, `SalatGlitch`, that specifically identifies errors that occur during serialization / deserialization. Note that there are still many points in code that throw RuntimeException (via sys.error) - overhaul/normalization of Salat's errors remains an outstanding TODO.
 
+- Previously case classes with fields of type `Int`, `Option[Int]`, `Seq[Int]`, or `Map[Int]` would experience narrowing with information loss, or a classcast exception when attempting to unbox the field value, if the deserialized a JSON or Mongo document contained a Double value in the field. In addition, a JSON document with goofy contents like `{"foo":"nine-point-oh"}` would return a `None`, swallowing the `NumberFormatException`, if `"foo"` was an `Option[Double]` or somesuch.  With this version, deserialization will fail more agressively if the JSON document has a field with a String in an invalid number format, or a Double literal that cannot be narrowed without loss of information (9.0001). Doubles that can be narrowed without loss will be converted to an Int, however (`9.0` converted to `9`, for example).

--- a/salat-core/src/test/scala/com/novus/salat/test/json/JsonModel.scala
+++ b/salat-core/src/test/scala/com/novus/salat/test/json/JsonModel.scala
@@ -96,6 +96,7 @@ case class Qvintus(bd: Option[BigDecimal])
 case class Rudolf(bi: Option[BigInt])
 case class Sigurd(o: Option[ObjectId])
 case class Tore(i: Int, d: Double, od: Option[Double])
+case class Ulrich(i: Int, oi: Option[Int], mi: Map[String, Int], list: List[Int])
 
 trait Foo
 case object Bar extends Foo

--- a/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
+++ b/salat-util/src/main/scala/com/novus/salat/TypeMatchers.scala
@@ -80,6 +80,7 @@ protected[salat] case class TypeFinder(t: TypeRefType) {
   lazy val isChar = TypeMatchers.matches(t, classOf[Char].getName)
   lazy val isFloat = TypeMatchers.matches(t, classOf[Float].getName)
   lazy val isDouble = TypeMatchers.matches(t, "scala.Double" :: "java.lang.Double" :: Nil)
+  lazy val isInt = TypeMatchers.matches(t, "scala.Int" :: "java.lang.Intger" :: Nil)
   lazy val isShort = TypeMatchers.matches(t, classOf[Short].getName)
   lazy val isBigDecimal = Types.isBigDecimal(t.symbol)
   lazy val isBigInt = Types.isBigInt(t.symbol)
@@ -90,7 +91,7 @@ protected[salat] case class TypeFinder(t: TypeRefType) {
   lazy val isURL = TypeMatchers.matches(t, classOf[java.net.URL].getName)
   lazy val isBSONTimestamp = TypeMatchers.matches(t, Types.BsonTimestamp)
 
-  lazy val directlyDeserialize = isDate || isDateTime || isLocalDateTime || isBSONTimestamp || isOid || isBigDecimal || isBigInt || isDouble
+  lazy val directlyDeserialize = isDate || isDateTime || isLocalDateTime || isBSONTimestamp || isOid || isBigDecimal || isBigInt || isDouble || isInt
 }
 
 protected[salat] object TypeMatchers {

--- a/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
+++ b/salat-util/src/main/scala/com/novus/salat/util/glitch.scala
@@ -38,6 +38,12 @@ class SalatGlitch(msg: String) extends Error(msg)
 // (at risk of breaking production code in the wild) could be to normalize all these ad-hoc errors to
 // specific, actionable errors.
 
+/** The target type of the value was incompatible with the type of the field. */
+case class IncompatibleTargetFieldType(msg: String, cause: Throwable) extends Error(msg, cause)
+object IncompatibleTargetFieldType {
+  def apply(msg: String): IncompatibleTargetFieldType = IncompatibleTargetFieldType(msg, null)
+}
+
 /**
  * Runtime error indicating that a class defines more than one constructor with args.
  *  @param clazz parameterized class instance


### PR DESCRIPTION
...or when reading a String int a Double or Int field that is not a valid Java number format.

Partially resolves #148 Maps and Seqs still could contain Doubles that will be narrowed to Ints.
