### PR TITLE
Fix error message for narrowing Double value to Float

### DIFF
--- a/salat-core/src/main/scala/salat/transformers/inject/Injectors.scala
+++ b/salat-core/src/main/scala/salat/transformers/inject/Injectors.scala
@@ -306,7 +306,7 @@ package in {
 
     def narrow_!(value: Any, converted: Float): Float =
       if (value == converted) converted else
-        throw IncompatibleTargetFieldType(s"will not narrow value to Int: $value")
+        throw IncompatibleTargetFieldType(s"will not narrow value to Float: $value")
 
     def narrow_!(parsed: Double): Int = {
       val asInt = parsed.intValue


### PR DESCRIPTION
The issue: when input value cannot be represented as Float without loss of precision, error message `will not narrow value to Int` is printed.

