### PR TITLE
bump casbah to 3.1.1

### DIFF
--- a/project/SalatBuild.scala
+++ b/project/SalatBuild.scala
@@ -140,7 +140,7 @@ object Publish {
 object Dependencies {
 
   private val LogbackVersion = "1.1.8"
-  private val CasbahVersion = "2.8.2"
+  private val CasbahVersion = "3.1.1"
 
   val specs2 = "org.specs2" %% "specs2" % "2.3.11" % "test"
   val commonsLang = "commons-lang" % "commons-lang" % "2.6" % "test"

--- a/salat-core/src/main/scala/salat/dao/SalatDAO.scala
+++ b/salat-core/src/main/scala/salat/dao/SalatDAO.scala
@@ -341,22 +341,6 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   override lazy val description = "SalatDAO[%s,%s](%s)".format(mot.runtimeClass.getSimpleName, mid.runtimeClass.getSimpleName, collection.name)
 
   /**
-   * Checks the "err" field in the write result, or the cached last error.
-   * "There should be no reason to use getError" - we found one.
-   */
-  private def defaultWriteResultErrorCheck(wr: WriteResult) = wr.getError != null || {
-    val lastError = wr.getCachedLastError
-    lastError != null && !lastError.ok()
-  }
-  /**
-   * Safety net for legacy code that is still using MongoConnection instead
-   * of MongoClient, and so will not reliably throw a MongoException.
-   */
-  private def handleLegacyErrors[T](wr: WriteResult, hasError: WriteResult => Boolean = defaultWriteResultErrorCheck _)(failure: => Nothing)(success: => T) = {
-    if (hasError(wr)) failure else success
-  }
-
-  /**
    * @param t instance of ObjectType
    *  @param wc write concern
    *  @return if insert succeeds, ID of inserted object
@@ -364,12 +348,8 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def insert(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
     try {
-      val wr = collection.insert(dbo, wc)
-      handleLegacyErrors(wr) {
-        throw SalatInsertError(description, collection, wc, wr, List(dbo))
-      } {
-        dbo.getAs[ID]("_id")
-      }
+      collection.insert(dbo, wc)
+      dbo.getAs[ID]("_id")
     }
     catch {
       case mex: MongoException =>
@@ -386,14 +366,10 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def insert(docs: Traversable[ObjectType], wc: WriteConcern = defaultWriteConcern) = if (docs.nonEmpty) {
     val dbos = docs.map(decorateDBO(_)).toList
     try {
-      val wr = collection.insert(dbos: _*)
-      handleLegacyErrors(wr) {
-        throw SalatInsertError(description, collection, wc, wr, dbos)
-      } {
-        dbos.map {
-          dbo =>
-            dbo.getAs[ID]("_id") orElse collection.findOne(dbo).flatMap(_.getAs[ID]("_id"))
-        }
+      collection.insert(dbos: _*)
+      dbos.map {
+        dbo =>
+          dbo.getAs[ID]("_id") orElse collection.findOne(dbo).flatMap(_.getAs[ID]("_id"))
       }
     }
     catch {
@@ -433,13 +409,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
   def remove(t: ObjectType, wc: WriteConcern) = {
     val dbo = decorateDBO(t)
     try {
-      val wr = collection.remove(dbo, wc)
-
-      handleLegacyErrors(wr) {
-        throw SalatRemoveError(description, collection, wc, wr, List(dbo))
-      } {
-        wr
-      }
+      collection.remove(dbo, wc)
     }
     catch {
       case mex: MongoException =>
@@ -454,13 +424,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def remove[A <% DBObject](q: A, wc: WriteConcern) = {
     try {
-      val wr = collection.remove(q, wc)
-
-      handleLegacyErrors(wr) {
-        throw SalatRemoveQueryError(description, collection, q, wc, wr)
-      } {
-        wr
-      }
+      collection.remove(q, wc)
     }
     catch {
       case mex: MongoException =>
@@ -495,13 +459,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
     val dbo = decorateDBO(t)
 
     try {
-      val wr = collection.save(dbo, wc)
-
-      handleLegacyErrors(wr) {
-        throw SalatSaveError(description, collection, wc, wr, List(dbo))
-      } {
-        wr
-      }
+      collection.save(dbo, wc)
     }
     catch {
       case mex: MongoException => throw SalatSaveError(description, collection, wc, Right(mex), List(dbo))
@@ -518,13 +476,7 @@ abstract class SalatDAO[ObjectType <: AnyRef, ID <: Any](val collection: MongoCo
    */
   def update(q: DBObject, o: DBObject, upsert: Boolean = false, multi: Boolean = false, wc: WriteConcern = defaultWriteConcern): WriteResult = {
     try {
-      val wr = collection.update(decorateQuery(q), o, upsert, multi, wc)
-
-      handleLegacyErrors(wr) {
-        throw SalatDAOUpdateError(description, collection, q, o, wc, wr, upsert, multi)
-      } {
-        wr
-      }
+      collection.update[DBObject, DBObject](decorateQuery(q), o, upsert, multi, wc)
     }
     catch {
       case mex: MongoException =>

--- a/salat-core/src/main/scala/salat/dao/SalatMongoCursor.scala
+++ b/salat-core/src/main/scala/salat/dao/SalatMongoCursor.scala
@@ -111,11 +111,7 @@ trait SalatMongoCursorBase[T <: AnyRef] extends Logging {
     this
   }
 
-  def numGetMores = underlying.numGetMores
-
   def numSeen = underlying.numSeen
-
-  def sizes = scala.collection.convert.Wrappers.JListWrapper(underlying.getSizes)
 
   def batchSize(n: Int) = {
     underlying.batchSize(n)

--- a/salat-core/src/test/scala/salat/test/dao/PolymorphicSalatDAOSpec.scala
+++ b/salat-core/src/test/scala/salat/test/dao/PolymorphicSalatDAOSpec.scala
@@ -130,7 +130,7 @@ class PolymorphicSalatDAOSpec extends SalatSpec {
       FooDAO.findOneById(bazId) must beSome(baz)
     }
     "update common fields across subclasses" in new fooContext {
-      FooDAO.update(q = DBObject.empty, o = DBObject("$inc" -> DBObject("x" -> 1)), upsert = false, multi = true).getN must_== 2
+      FooDAO.update(q = DBObject.empty, o = DBObject("$inc" -> DBObject("x" -> 1)), upsert = false, multi = true, wc = WriteConcern.Acknowledged).getN must_== 2
       FooDAO.findOneById(barId).map(_.x) must beSome(2)
       FooDAO.findOneById(bazId).map(_.x) must beSome(0)
     }
@@ -173,7 +173,7 @@ class PolymorphicSalatDAOSpec extends SalatSpec {
       val bar2Id = new ObjectId
       val bar2 = Bar(_id = bar2Id, x = 5, y = "flight", z = 89.8)
       BarDAO.insert(bar2) must beSome(bar2Id)
-      BarDAO.update(q = DBObject.empty, o = DBObject("$inc" -> DBObject("x" -> 1)), upsert = false, multi = true).getN must_== 2
+      BarDAO.update(q = DBObject.empty, o = DBObject("$inc" -> DBObject("x" -> 1)), upsert = false, multi = true, wc = WriteConcern.Acknowledged).getN must_== 2
       BarDAO.findOneById(barId).map(_.x) must beSome(bar.x + 1)
       BarDAO.findOneById(bar2Id).map(_.x) must beSome(bar2.x + 1)
       FooDAO.findOneById(bazId).map(_.x) must beSome(baz.x) // BarDAO update query did not affect instances of Baz!

--- a/salat-core/src/test/scala/salat/test/dao/SalatDAOSpec.scala
+++ b/salat-core/src/test/scala/salat/test/dao/SalatDAOSpec.scala
@@ -114,32 +114,12 @@ class SalatDAOSpec extends SalatSpec {
       }
     }
 
-    "handle legacy errors when inserting an object having a duplicate key" in new alphaContext {
-      DeprecatedAlphaDAO.insert(alpha7)
-      DeprecatedAlphaDAO.insert(alpha7) must throwA[SalatInsertError]
-    }
-
-    "handle legacy errors for bulk inserts where an object has a duplicate key" in new alphaContext {
-      DeprecatedAlphaDAO.insert(alpha7)
-
-      // Note: Mongo stops processing at the first dup in the list
-      val errorMustOccur = DeprecatedAlphaDAO.insert(List(alpha7, alpha1, alpha2, alpha3)) must throwA[SalatInsertError]
-      val onlyOneRecord = DeprecatedAlphaDAO.collection.count() must_== 1
-
-      errorMustOccur and onlyOneRecord
-    }
-
     "handle MongoExceptions for invalid updates" in new alphaContext {
       AlphaDAO.insert(alpha7)
       AlphaDAO.update(MongoDBObject.empty, MongoDBObject("_id" -> 1)) must throwA[SalatDAOUpdateError].like {
         case ex: SalatDAOUpdateError =>
           ex.getCause must beAnInstanceOf[WriteConcernException]
       }
-    }
-
-    "handle legacy errors for invalid updates" in new alphaContext {
-      DeprecatedAlphaDAO.insert(alpha7)
-      DeprecatedAlphaDAO.update(MongoDBObject.empty, MongoDBObject("_id" -> 1)) must throwA[SalatDAOUpdateError]
     }
 
     "support findOne returning Option[T]" in new alphaContext {
@@ -174,7 +154,7 @@ class SalatDAOSpec extends SalatSpec {
         t      = alpha3.copy(beta = List[Beta](Gamma("gamma3"))),
         upsert = false,
         multi  = false,
-        wc     = new WriteConcern()
+        wc     = WriteConcern.Acknowledged
       )
       wr.getN must_== 1L
 


### PR DESCRIPTION
Hello!

I work on infrastructure at Foursquare. We recently ran into an issue with one of our open source projects using this library after upgrading to version 3 of the mongo-java-driver (that issue is [here](https://github.com/foursquare/fsqio/issues/33)). The immediate fix there to unblock us is to upgrade this library to be compatible with the newer mongo code, and I would like to contribute that back here if others find it useful.

It's worth noting our use of Salat is very minor -- it exists as a one-off in a set of utility scripts used with the Twofishes project, so this has had very little production testing. However, I did run your automated test suite and everything seems in order there.

Let me know if this patch is of interest or if there is any additional work you'd like to see here.